### PR TITLE
fix a warning during the helm upgrade

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -252,7 +252,7 @@ jupyterhub:
         memory: 256Mi
       limits:
         memory: 2Gi
-    extraEnv:
+    # extraEnv:
       # This is unfortunately still needed by canvas auth
       # OAUTH2_AUTHORIZE_URL: https://bcourses.berkeley.edu/login/oauth2/auth
     extraConfig:


### PR DESCRIPTION
the empty `extraEnv` was causing a warning during deployment, so let's comment that out for now