### PR TITLE
bump chp to 5.0.0-beta.1

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -50,6 +50,8 @@ jupyterhub:
           sysctls:
             - name: net.ipv4.ip_local_port_range
               value: "10000 65000"
+      image:
+        tag: 5.0.0-beta.1
       # extraCommandLineFlags:
         # set the timeout and proxyTimeout to 5 seconds
         # https://github.com/http-party/node-http-proxy?tab=readme-ov-file#options


### PR DESCRIPTION
testing `chp` 5.0.0-beta.1

ref: https://github.com/jupyterhub/configurable-http-proxy/issues/557#issuecomment-2886225581