### PR TITLE
move from kubernetes.io/ingress.class to ingressClassName: nginx to squelch deprecation warning

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -9,9 +9,9 @@ jupyterhub:
       pullOnlyOnChanges: true
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 256m
-      kubernetes.io/ingress.class: nginx
       cert-manager.io/cluster-issuer: letsencrypt-prod
       acme.cert-manager.io/http01-edit-in-place: "true"
   scheduling:

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -121,6 +121,7 @@ grafana:
 
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       # Increase timeout for each query made by the grafana frontend to the
       # grafana backend to 2min, which is the default timeout for prometheus
@@ -129,7 +130,7 @@ grafana:
       # to allow prometheus the best chance of executing queries we care about.
       # See: https://github.com/2i2c-org/infrastructure/pull/2942
       nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
-      kubernetes.io/ingress.class: nginx
+
       cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - grafana.jupyter.cal-icor.org


### PR DESCRIPTION
this is visible when you run `hubploy`:

```
W0516 18:07:20.031214    2291 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

this change fixes this.  i will test locally before merging.

@yijunge-ucb @felder you should consider doing this for datahub.

ref:  https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/#multiple-ingress-controllers