### PR TITLE
add hubploy + filestore homedir creation functionality

### DIFF
--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -2,6 +2,7 @@
 # This file should be copied to <name of deployment>.yaml and kept in the
 # _deploy_configs directory.
 hub_name: 
+hub_filestore_instance: shared-filestore # change if needed
 institution: 
 institution_url: 
 institution_logo_url: 

--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -2,7 +2,8 @@
 # This file should be copied to <name of deployment>.yaml and kept in the
 # _deploy_configs directory.
 hub_name: 
-hub_filestore_instance: shared-filestore # change if needed
+hub_filestore_instance: shared-filestore
+hub_filestore_ip: 10.183.114.2
 institution: 
 institution_url: 
 institution_logo_url: 

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -9,7 +9,6 @@
     "pool_name": "base-pool",
     "hub_filestore_share": "shares",
     "hub_filestore_ip": "10.183.114.2",
-    "hub_filestore_instance": "shared-filestore",
     "hub_filestore_capacity": "1T",
     "authenticator_class": "valid-auth-class",
     "authenticator_class_instance": "valid-auth-instance",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -9,6 +9,7 @@
     "pool_name": "base-pool",
     "hub_filestore_share": "shares",
     "hub_filestore_ip": "10.183.114.2",
+    "hub_filestore_instance": "shared-filestore",
     "hub_filestore_capacity": "1T",
     "authenticator_class": "valid-auth-class",
     "authenticator_class_instance": "valid-auth-instance",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -8,7 +8,6 @@
     "cluster_name": "spring-2025",
     "pool_name": "base-pool",
     "hub_filestore_share": "shares",
-    "hub_filestore_ip": "10.183.114.2",
     "hub_filestore_capacity": "1T",
     "authenticator_class": "valid-auth-class",
     "authenticator_class_instance": "valid-auth-instance",

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import yaml
 from cookiecutter.main import cookiecutter
+from hubploy import helm
 
 
 def delete_file(filepath):
@@ -314,6 +315,12 @@ def main():
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
+        "--deploy",
+        "-d",
+        action="store_true",
+        help="If set, the script will deploy the hub after creating the PR.",
+    )
+    parser.add_argument(
         "--github_user",
         "-g",
         type=str,
@@ -367,6 +374,11 @@ def main():
         exit(1)
 
     create_deployment(config, args.github_user, root_path, args.manual_config)
+
+    if args.deploy:
+        print(f"Deploying the hub to {config["hub_name"]}-staging.")
+        helm.deploy(hub=config["hub_name"], chart="hub", environment="staging")
+        print(f"Deployment to {config['hub_name']}-staging complete.")
 
 
 if __name__ == "__main__":

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -398,7 +398,7 @@ def main():
     create_deployment(config, args.github_user, root_path, args.manual_config)
 
     if args.deploy:
-        print(f"Deploying the hub to {config["hub_name"]}-staging.")
+        print(f"Deploying the hub to {config['hub_name']}-staging.")
         helm.deploy(hub=config["hub_name"], chart="hub", environment="staging")
         print(f"Deployment to {config['hub_name']}-staging complete.")
 

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -280,6 +280,27 @@ def create_deployment(config, github_user, root_path, manual_config=False):
         root_path (str): The parent path where the deployment will be created.
         manual_config (bool): If True, the script will ask for confirmation for each step.
     """
+    # create the prod and staging directories on filestore for the new hub
+    print(f"Creating directories for {config['hub_name']} on filestore.")
+    try:
+        subprocess.check_call(
+            [
+                "gcloud",
+                "compute",
+                "ssh",
+                "nfsserver",
+                "--tunnel-through-iap",
+                "--zone=us-central1-b",
+                "--command",
+                "sudo -u ubuntu install -d -o 1000 -g 1000 "
+                + f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/prod "
+                + f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/staging",
+            ]
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error creating directories for {config['hub_name']}: {e}")
+        exit(1)
+
     # Create a feature branch
     branch_name = f"add-{config['hub_name']}-deployment"
     create_branch(branch_name, root_path)

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -289,6 +289,7 @@ def create_deployment(config, github_user, root_path, manual_config=False):
     populate_deployment_config(config, root_path, manual_config)
 
     # Create labels for the new hub
+    print(f"Creating repo and github labels for {config['hub_name']}.")
     github_label = create_label(config["hub_name"], root_path)
 
     # Stage the new deployment files


### PR DESCRIPTION
the script now creates the filestore homedirs for the deployment, and will also deploy via `hubploy` to `staging` if you pass the `--deploy/-d` flag when it's executed.

fwiw adding `hubploy` to this was a LOT easier than i had anticipated.  i did a bunch of changes to the `jupyter` hub's config (common and hubploy), and was able to ensure that the proper stuff was getting deployed!

```
>>> hub='jupyter'
>>> from hubploy import helm
>>> helm.deploy(deployment=hub, chart='hub', environment='staging')
Activated service account credentials for: [hubploy-922@cal-icor-hubs.iam.gserviceaccount.com]
Fetching cluster endpoint and auth data.
kubeconfig entry generated for spring-2025.
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://jupyterhub.github.io/helm-chart/" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "autoscaler" chart repository
...Successfully got an update from the "grafana" chart repository
...Successfully got an update from the "prometheus-community" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "jupyterhub" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading jupyterhub from repo https://jupyterhub.github.io/helm-chart/
Deleting outdated charts
Release "jupyter-staging" has been upgraded. Happy Helming!
NAME: jupyter-staging
LAST DEPLOYED: Fri May 23 11:11:15 2025
NAMESPACE: jupyter-staging
STATUS: deployed
REVISION: 52
TEST SUITE: None
Updated property [core/account].
>>>
```