### PR TITLE
Create Deployment: Updated for Github Auth Config

### DIFF
--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -16,8 +16,9 @@ staging:
   secret: 
 admin_emails:
   - 
-authenticator_class: cilogon
-authenticator_class_instance: "CILogonOAuthenticator"
-idp_url:   http://login.microsoftonline.com/common/oauth2/v2.0/authorize
-idp_allowed_domains: "" # This is an empty string or a yaml list e.g. - my.cuesta.edu
-allow_all: "" # This is either an empty string or true but only when idp_allowed_domains is empty
+authenticator_class: cilogon # This is either cilogon or github
+authenticator_class_instance: "CILogonOAuthenticator" # This is either "CILogonOAuthenticator" or "GitHubOAuthenticator"
+idp_url: "" # cilogon only e.g.  http://login.microsoftonline.com/common/oauth2/v2.0/authorize
+idp_allowed_domains: "" # cilogon only: Microsoft or Google Auth Schemes only  e.g, This is an empty string or a yaml list e.g. - my.cuesta.edu
+allow_all: "" # cilogon only: Shibboleth or inCommon auth schemes set allow_all to true; this is an empty string for google and microsoft auth schemes
+allowed_organizations: "" # github only: This is an empty string or This is a yaml list e.g. - LACC-Statistical-Data-Analytics

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -21,5 +21,6 @@
     "client_id_prod": "valid-client-id-production",
     "client_secret_prod": "valid-client-secret-production",
     "idp_allowed_domains": "",
-    "allow_all": ""
+    "allow_all": "",
+    "allowed_organizations": ""
 }

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: {{cookiecutter.authenticator_class}}
       {{cookiecutter.authenticator_class_instance}}:
+        {%- if cookiecutter.authenticator_class == "cilogon" %}
         allowed_idps:
           {{cookiecutter.idp_url}}:
             default: true
@@ -46,6 +47,14 @@ jupyterhub:
           http://google.com/accounts/o8/id:
             username_derivation:
               username_claim: "email"
+        {%- elif cookiecutter.authenticator_class == "github" %}
+        allowed_organizations:
+          {%- for org in cookiecutter.allowed_organizations.split(',') %}
+          - {{ org.strip() }}
+          {%- endfor %}
+        scope:
+          - read:org
+        {%- endif %}
       Authenticator:
         manage_groups: false
         admin_users:

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -264,6 +264,9 @@ def populate_deployment_config(config, root_path, manual_config):
             "idp_allowed_domains": ", ".join(
                 domain for domain in config["idp_allowed_domains"]
             ),
+            "allowed_organizations": ", ".join(
+                org for org in config["allowed_organizations"]
+            ),
             "allow_all": config["allow_all"],
             "admin_emails": ", ".join(email for email in config["admin_emails"]),
         },


### PR DESCRIPTION
I tested the config file creation when Github Auth is needed as well as confirmed it matches the LACC config; I did not deploy a hub that is using Github Oauth so the next time an organization needs Github Auth we need to double check that the deployment works correctly which we always do anyway.