### PR TITLE
bumping urllib3 for cves

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,5 +10,5 @@ pre-commit==4.0.1
 pygithub==2.4.0
 pyrsistent==0.19.3
 ruff==0.7.0
-urllib3==2.2.3
+urllib3==2.5.0
 yamllint==1.35.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ myst-parser==4.0.0
 niquests==3.7.2
 pygithub==2.4.0
 pyrsistent==0.19.3
-urllib3==2.2.3
+urllib3==2.5.0
 yamllint==1.35.1


### PR DESCRIPTION
the previous version had 2 moderate CVEs...  bumping to latest.

https://github.com/cal-icor/cal-icor-hubs/security/dependabot