### PR TITLE
enable `manage_groups` for dvc

### DIFF
--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -47,7 +47,7 @@ jupyterhub:
             allowed_domains:
               - dvc.edu
       Authenticator:
-        manage_groups: false
+        manage_groups: true
         admin_users:
           - sknapp@berkeley.edu
           - ericvd@berkeley.edu


### PR DESCRIPTION
since this is one of our more visited hubs, and we need to explore user groups, let's enable `manage_groups` and see if cilogon gets us anything useful.

@sean-morris 