### PR TITLE
enable shared readonly/readwrite folders

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -466,18 +466,16 @@ jupyterhub:
               await asyncio.sleep(self.spawn_launcher_delay)
 
             # give admins read/write access to the shared folder
-            admins = z2jh.get_config('hub.config.Authenticator.admin_users')
             volume_mounts = self.volume_mounts
-            for admin in admins:
-              if self.user.name == admin:
-                count = 0
-                for v in volume_mounts:
-                  if v.get('mountPath') == '/home/jovyan/shared':
-                    v['readOnly'] = False
-                    v['mountPath'] = '/home/jovyan/shared_readwrite'
-                    self.log.warning(f'Giving {self.user.name} read/write access to shared folder')
-                    self.volume_mounts[count] = v
-                  count += 1
+            if self.user.admin:
+              count = 0
+              for v in volume_mounts:
+                if v.get('mountPath') == '/home/jovyan/shared':
+                  v['readOnly'] = False
+                  v['mountPath'] = '/home/jovyan/shared_readwrite'
+                  self.log.info(f'Giving {self.user.name} read/write access to shared folder')
+                  self.volume_mounts[count] = v
+                count += 1
 
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -84,27 +84,33 @@ jupyterhub:
         - -cx
         args:
           - |
-            echo Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS...
+            ls -ld /home/jovyan/shared
+            echo "Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS..."
             if [ "$SHARED_ACCESS" = "read_write" ]; then
                 # For admins (instructors): give read/write/execute to owner, and read/execute to group.
                 # Adjust owner/group as necessary for your NFS setup.
                 # If you don't have specific group needs, 'root:root' can work if your pod runs as root initially.
-                chmod -R 770 /home/jovyan/shared
-                # Example: chown root:root /shared  (Adjust user/group as needed for your NFS)
+                chmod 0770 /home/jovyan/shared
+                # Example: chown root:root /home/jovyan/shared  (Adjust user/group as needed for your NFS)
             else
               # For regular users: give read/execute to owner and read/execute to group.
               # This effectively makes it read-only for them.
-              chmod -R 750 /home/jovyan/shared
+              chmod 0550 /home/jovyan/shared
               # Example: chown root:root /shared (Adjust user/group as needed for your NFS)
             fi
-            echo Permissions set for /shared.
+            echo "Permissions set for /home/jovyan/shared."
+            ls -ld /home/jovyan/shared
         env:
-          # This env var will be populated by the pre_spawn_hook
+          # This env var will be populated by the pre_spawn_hook somehow?
           - name: SHARED_ACCESS
-            value: "" # read_only
+            value: "read_write" # "read_only"
         volumeMounts:
-          - name: home-nfs-v3
+          - name: home
+            mountPath: /home/jovyan
+            subPath: "{escaped_username}"
+          - name: home
             mountPath: /home/jovyan/shared
+            subPath: _shared
         securityContext:
           # Init containers often need to run as root to change permissions
           runAsUser: 0

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -474,7 +474,6 @@ jupyterhub:
                   v['readOnly'] = False
                   v['mountPath'] = '/home/jovyan/shared_readwrite'
                   self.log.info(f'Giving {self.user.name} read/write access to shared folder')
-                  self.volume_mounts[count] = v
                 count += 1
 
             # custom.memory

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -185,12 +185,43 @@ jupyterhub:
 
   hub:
     initContainers:
+      - name: set-shared-perms
+        image: busybox:1.36.1
+        command:
+        - sh
+        - -cx
+        args:
+          - |
+            echo Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS...
+            if [ $SHARED_ACCESS = read_write ]; then
+                # For admins (instructors): give read/write/execute to owner, and read/execute to group.
+                # Adjust owner/group as necessary for your NFS setup.
+                # If you don't have specific group needs, 'root:root' can work if your pod runs as root initially.
+                chmod -R 770 /shared
+                # Example: chown root:root /shared  (Adjust user/group as needed for your NFS)
+            else
+              # For regular users: give read/execute to owner and read/execute to group.
+              # This effectively makes it rea-only for them.
+              chmod -R 750 /shared
+              # Example: chown root:root /shared (Adjust user/group as needed for your NFS)
+            fi
+            echo Permissions set for /shared.
+        env:
+          # This env var will be populated by the pre_spawn_hook
+          - name: SHARED_ACCESS
+            value: read_only
+        volumeMounts:
+          name: shared-volume
+          mountPath: /home/jovyan/shared
+        securityContext:
+          # Init containers often need to run as root to change permissions
+          runAsUser: 0
       - name: templates-clone
         image: alpine/git:2.40.1
         command:
           - /bin/sh
         args:
-          - -c
+          - -cx
           # Remove the existing repo first if it exists, as otherwise we will
           # error out when the pod restarts. /srv/extra-templates-dir is an
           # emptyDir volume, so it is *not* cleaned up when the pod's containers restarts -
@@ -374,7 +405,22 @@ jupyterhub:
             'custom': get_config('custom.homepage.templateVars')
         })
 
-      02-custom-attr-spawner: |
+      02-custom-attr-spawner-shared: |
+        def set_shared_access_permissions(spawner):
+          """
+          Determines if the user is an admin and sets an environment variable
+          in the user's pod to control shared folder access.
+          """
+          is_admin = spawner.user.admin
+          if is_admin:
+              spawner.environment["SHARED_ACCESS"] = "read_write"
+          else:
+              spawner.environment["SHARED_ACCESS"] = "read_only"
+
+        # Register the hook
+        c.Spawner.pre_spawn_hook = set_shared_access_permissions
+
+      03-custom-attr-spawner: |
         import asyncio
         import os
         import time

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -193,26 +193,26 @@ jupyterhub:
         args:
           - |
             echo Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS...
-            if [ $SHARED_ACCESS = read_write ]; then
+            if [ "$SHARED_ACCESS" = "read_write" ]; then
                 # For admins (instructors): give read/write/execute to owner, and read/execute to group.
                 # Adjust owner/group as necessary for your NFS setup.
                 # If you don't have specific group needs, 'root:root' can work if your pod runs as root initially.
-                chmod -R 770 /shared
+                chmod -R 770 /home/jovyan/shared
                 # Example: chown root:root /shared  (Adjust user/group as needed for your NFS)
             else
               # For regular users: give read/execute to owner and read/execute to group.
-              # This effectively makes it rea-only for them.
-              chmod -R 750 /shared
+              # This effectively makes it read-only for them.
+              chmod -R 750 /home/jovyan/shared
               # Example: chown root:root /shared (Adjust user/group as needed for your NFS)
             fi
             echo Permissions set for /shared.
         env:
           # This env var will be populated by the pre_spawn_hook
           - name: SHARED_ACCESS
-            value: read_only
+            value: "" # read_only
         volumeMounts:
-          name: shared-volume
-          mountPath: /home/jovyan/shared
+          - name: home-nfs-v3
+            mountPath: /home/jovyan/shared
         securityContext:
           # Init containers often need to run as root to change permissions
           runAsUser: 0

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -76,6 +76,38 @@ jupyterhub:
       letsencrypt:
         contactEmail: calicor-letsencrypt@berkeley.edu
   singleuser:
+    initContainers:
+      - name: set-shared-perms
+        image: busybox:1.36.1
+        command:
+        - sh
+        - -cx
+        args:
+          - |
+            echo Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS...
+            if [ "$SHARED_ACCESS" = "read_write" ]; then
+                # For admins (instructors): give read/write/execute to owner, and read/execute to group.
+                # Adjust owner/group as necessary for your NFS setup.
+                # If you don't have specific group needs, 'root:root' can work if your pod runs as root initially.
+                chmod -R 770 /home/jovyan/shared
+                # Example: chown root:root /shared  (Adjust user/group as needed for your NFS)
+            else
+              # For regular users: give read/execute to owner and read/execute to group.
+              # This effectively makes it read-only for them.
+              chmod -R 750 /home/jovyan/shared
+              # Example: chown root:root /shared (Adjust user/group as needed for your NFS)
+            fi
+            echo Permissions set for /shared.
+        env:
+          # This env var will be populated by the pre_spawn_hook
+          - name: SHARED_ACCESS
+            value: "" # read_only
+        volumeMounts:
+          - name: home-nfs-v3
+            mountPath: /home/jovyan/shared
+        securityContext:
+          # Init containers often need to run as root to change permissions
+          runAsUser: 0
     cmd:
       # Explicitly define this, as it's no longer set by z2jh
       # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449
@@ -185,43 +217,12 @@ jupyterhub:
 
   hub:
     initContainers:
-      - name: set-shared-perms
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -cx
-        args:
-          - |
-            echo Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS...
-            if [ "$SHARED_ACCESS" = "read_write" ]; then
-                # For admins (instructors): give read/write/execute to owner, and read/execute to group.
-                # Adjust owner/group as necessary for your NFS setup.
-                # If you don't have specific group needs, 'root:root' can work if your pod runs as root initially.
-                chmod -R 770 /home/jovyan/shared
-                # Example: chown root:root /shared  (Adjust user/group as needed for your NFS)
-            else
-              # For regular users: give read/execute to owner and read/execute to group.
-              # This effectively makes it read-only for them.
-              chmod -R 750 /home/jovyan/shared
-              # Example: chown root:root /shared (Adjust user/group as needed for your NFS)
-            fi
-            echo Permissions set for /shared.
-        env:
-          # This env var will be populated by the pre_spawn_hook
-          - name: SHARED_ACCESS
-            value: "" # read_only
-        volumeMounts:
-          - name: home-nfs-v3
-            mountPath: /home/jovyan/shared
-        securityContext:
-          # Init containers often need to run as root to change permissions
-          runAsUser: 0
       - name: templates-clone
         image: alpine/git:2.40.1
         command:
           - /bin/sh
         args:
-          - -cx
+          - -c
           # Remove the existing repo first if it exists, as otherwise we will
           # error out when the pod restarts. /srv/extra-templates-dir is an
           # emptyDir volume, so it is *not* cleaned up when the pod's containers restarts -

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -468,13 +468,11 @@ jupyterhub:
             # give admins read/write access to the shared folder
             volume_mounts = self.volume_mounts
             if self.user.admin:
-              count = 0
               for v in volume_mounts:
                 if v.get('mountPath') == '/home/jovyan/shared':
                   v['readOnly'] = False
                   v['mountPath'] = '/home/jovyan/shared_readwrite'
                   self.log.info(f'Giving {self.user.name} read/write access to shared folder')
-                count += 1
 
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -76,44 +76,6 @@ jupyterhub:
       letsencrypt:
         contactEmail: calicor-letsencrypt@berkeley.edu
   singleuser:
-    initContainers:
-      - name: set-shared-perms
-        image: busybox:1.36.1
-        command:
-        - sh
-        - -cx
-        args:
-          - |
-            ls -ld /home/jovyan/shared
-            echo "Setting permissions for shared access based on SHARED_ACCESS=$SHARED_ACCESS..."
-            if [ "$SHARED_ACCESS" = "read_write" ]; then
-                # For admins (instructors): give read/write/execute to owner, and read/execute to group.
-                # Adjust owner/group as necessary for your NFS setup.
-                # If you don't have specific group needs, 'root:root' can work if your pod runs as root initially.
-                chmod 0770 /home/jovyan/shared
-                # Example: chown root:root /home/jovyan/shared  (Adjust user/group as needed for your NFS)
-            else
-              # For regular users: give read/execute to owner and read/execute to group.
-              # This effectively makes it read-only for them.
-              chmod 0550 /home/jovyan/shared
-              # Example: chown root:root /shared (Adjust user/group as needed for your NFS)
-            fi
-            echo "Permissions set for /home/jovyan/shared."
-            ls -ld /home/jovyan/shared
-        env:
-          # This env var will be populated by the pre_spawn_hook somehow?
-          - name: SHARED_ACCESS
-            value: "read_write" # "read_only"
-        volumeMounts:
-          - name: home
-            mountPath: /home/jovyan
-            subPath: "{escaped_username}"
-          - name: home
-            mountPath: /home/jovyan/shared
-            subPath: _shared
-        securityContext:
-          # Init containers often need to run as root to change permissions
-          runAsUser: 0
     cmd:
       # Explicitly define this, as it's no longer set by z2jh
       # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449
@@ -412,22 +374,7 @@ jupyterhub:
             'custom': get_config('custom.homepage.templateVars')
         })
 
-      02-custom-attr-spawner-shared: |
-        def set_shared_access_permissions(spawner):
-          """
-          Determines if the user is an admin and sets an environment variable
-          in the user's pod to control shared folder access.
-          """
-          is_admin = spawner.user.admin
-          if is_admin:
-              spawner.environment["SHARED_ACCESS"] = "read_write"
-          else:
-              spawner.environment["SHARED_ACCESS"] = "read_only"
-
-        # Register the hook
-        c.Spawner.pre_spawn_hook = set_shared_access_permissions
-
-      03-custom-attr-spawner: |
+      02-custom-attr-spawner: |
         import asyncio
         import os
         import time
@@ -517,6 +464,20 @@ jupyterhub:
             # https://github.com/berkeley-dsep-infra/datahub/issues/4237
             if self.spawn_launcher_delay:
               await asyncio.sleep(self.spawn_launcher_delay)
+
+            # give admins read/write access to the shared folder
+            admins = z2jh.get_config('hub.config.Authenticator.admin_users')
+            volume_mounts = self.volume_mounts
+            for admin in admins:
+              if self.user.name == admin:
+                count = 0
+                for v in volume_mounts:
+                  if v.get('mountPath') == '/home/jovyan/shared':
+                    v['readOnly'] = False
+                    v['mountPath'] = '/home/jovyan/shared_readwrite'
+                    self.log.warning(f'Giving {self.user.name} read/write access to shared folder')
+                    self.volume_mounts[count] = v
+                  count += 1
 
             # custom.memory
             custom_memory = z2jh.get_config('custom.memory', {})

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -470,8 +470,10 @@ jupyterhub:
             if self.user.admin:
               for v in volume_mounts:
                 if v.get('mountPath') == '/home/jovyan/shared':
-                  v['readOnly'] = False
-                  v['mountPath'] = '/home/jovyan/shared_readwrite'
+                  rw = v.copy()
+                  rw['readOnly'] = False
+                  rw['mountPath'] = '/home/jovyan/shared_readwrite'
+                  volume_mounts.append(rw)
                   self.log.info(f'Giving {self.user.name} read/write access to shared folder')
 
             # custom.memory


### PR DESCRIPTION
# add initial functionality for readonly/readwrite folders

## initial proposed changes

### regular users

upon logging in, they see a top-level directory in their homedir named `shared`, and have read access to the entire folder.

### admin users

upon logging in, they see two top-level directories in their homedir named `shared` and `shared_readwrite`.  they have have full read/write access to everything living under `shared_readwrite`, and identical behavior to regular users for the `shared` directory.  this lets instructors work on files in `shared_readwrite`, and test the notebooks for their students using the `shared` folder.

## future proposed changes

### more granular access control for sub-folders under `_shared`

using the `custom:` stanzas in different hubs, limit write access for certain admins based on a course/class definition in a hub.  some difficulties i see with this are based off of the fact that we cannot get groups/roles through CILogon (only github will let us do this).  this means that for orgs using CILogon, we will be able to limit *write* access for admins based on manually-defined groups, it will be much more difficult to manage *read only* access for regular users.

## additional TODOs

for all currently deployed hubs w/shared folders, change `readOnly` from `false` to `true` in all hub configs.

## shortcomings

- all regular users can see everything in the `shared` folder
- all admin users have read/write access to everything in the `shared_readwrite` folder