### PR TITLE
update hub deployment/creation script to add shared dirs, templated/commented out configs for shared dirs in all hubs, and set `readOnly` to `true` for hubs currently deployed with shared folders

### DIFF
--- a/deployments/csub/config/common.yaml
+++ b/deployments/csub/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csueb/config/common.yaml
+++ b/deployments/csueb/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csulb/config/common.yaml
+++ b/deployments/csulb/config/common.yaml
@@ -76,6 +76,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csum/config/common.yaml
+++ b/deployments/csum/config/common.yaml
@@ -67,6 +67,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -71,7 +71,7 @@ jupyterhub:
         - name: home
           mountPath: /home/jovyan/shared
           subPath: _shared
-          readOnly: false
+          readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csusj/config/common.yaml
+++ b/deployments/csusj/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/cuesta/config/common.yaml
+++ b/deployments/cuesta/config/common.yaml
@@ -63,6 +63,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -91,6 +91,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/evc/config/common.yaml
+++ b/deployments/evc/config/common.yaml
@@ -73,6 +73,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -65,6 +65,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -102,7 +102,7 @@ jupyterhub:
         - name: home
           mountPath: /home/jovyan/shared
           subPath: _shared
-          readOnly: false
+          readOnly: true
     memory:
       guarantee: 1G
       limit: 2G

--- a/deployments/lacc/config/common.yaml
+++ b/deployments/lacc/config/common.yaml
@@ -77,6 +77,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -84,6 +84,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/ucla/config/common.yaml
+++ b/deployments/ucla/config/common.yaml
@@ -83,6 +83,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -66,6 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -67,6 +67,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -305,7 +305,9 @@ def create_deployment(
                 "--command",
                 "sudo -u ubuntu install -d -o 1000 -g 1000 "
                 + f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/prod "
-                + f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/staging",
+                + f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/prod/_shared ",
+                +f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/staging ",
+                +f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/staging/_shared",
             ]
         )
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
- add default/commented out shared folder defs for all hub configs
- automatically create the `_shared` folder on filestore for any new deployments

this needs to be merged after https://github.com/cal-icor/cal-icor-hubs/pull/251 to enable proper extraVolumeMountings.

