### PR TITLE
Move shared folder config to common config

### DIFF
--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -67,11 +67,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared
-          subPath: _shared
-          readOnly: true
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -66,11 +66,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared
-          subPath: _shared
-          readOnly: true
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -98,11 +98,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      extraVolumeMounts:
-        - name: home
-          mountPath: /home/jovyan/shared
-          subPath: _shared
-          readOnly: true
+      # extraVolumeMounts:
+      #   - name: home
+      #     mountPath: /home/jovyan/shared
+      #     subPath: _shared
+      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 2G

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -169,6 +169,13 @@ jupyterhub:
                   - 192.168.0.0/16
               # Don't allow network access to the metadata IP
                   - 169.254.169.254/32
+    storage:
+      extraVolumeMounts:
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
+
 
   custom:
     homepage:


### PR DESCRIPTION
this will enable shared + shared/readwrite folders for all hubs, instead of enabling this on a hub-by-hub basis.

i tested this manually on staging.jupyter.cal-icor.org w/o issue.