### PR TITLE
updating to use the new scaler release

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: node-placeholder-scaler
-    version: 0.0.1-0.dev.git.1.h8e4c41d
+    version: 0.0.1-0.dev.git.323.hbdd0188
     repository: oci://us-central1-docker.pkg.dev/cal-icor-hubs/helm-charts
   - name: prometheus-statsd-exporter
     version: 0.11.0

--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: node-placeholder-scaler
-    version: 0.0.1-0.dev.git.323.hbdd0188
+    version: 0.0.1-0.dev.git.1.h167f609
     repository: oci://us-central1-docker.pkg.dev/cal-icor-hubs/helm-charts
   - name: prometheus-statsd-exporter
     version: 0.11.0

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -189,6 +189,8 @@ node-placeholder-scaler:
   calendarUrl: 
     https://calendar.google.com/calendar/ical/c_35d90f50598c1472a4154c538bb49a21eabd8be93831d7de345d53fea8e19390%40group.calendar.google.com/public/basic.ics
 
+  calendarTimezone: "America/Los_Angeles"
+
   nodePools:
     # short name of the node pool, used in the calendar event description
     base:


### PR DESCRIPTION
using the soon-to-be-merged changes in https://github.com/cal-icor/jupyterhub-k8s-node-placeholder/pull/16