### PR TITLE
merging 272/274/275/276 to prod

### DIFF
--- a/deployments/csub/hubploy.yaml
+++ b/deployments/csub/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csub/hubploy.yaml
+++ b/deployments/csub/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csub/hubploy.yaml
+++ b/deployments/csub/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csub/hubploy.yaml
+++ b/deployments/csub/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csueb/hubploy.yaml
+++ b/deployments/csueb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csueb/hubploy.yaml
+++ b/deployments/csueb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csueb/hubploy.yaml
+++ b/deployments/csueb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csueb/hubploy.yaml
+++ b/deployments/csueb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csuf/hubploy.yaml
+++ b/deployments/csuf/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csuf/hubploy.yaml
+++ b/deployments/csuf/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csuf/hubploy.yaml
+++ b/deployments/csuf/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csuf/hubploy.yaml
+++ b/deployments/csuf/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csula/hubploy.yaml
+++ b/deployments/csula/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csula/hubploy.yaml
+++ b/deployments/csula/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csula/hubploy.yaml
+++ b/deployments/csula/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csula/hubploy.yaml
+++ b/deployments/csula/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csulb/hubploy.yaml
+++ b/deployments/csulb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csulb/hubploy.yaml
+++ b/deployments/csulb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csulb/hubploy.yaml
+++ b/deployments/csulb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csulb/hubploy.yaml
+++ b/deployments/csulb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csum/hubploy.yaml
+++ b/deployments/csum/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csum/hubploy.yaml
+++ b/deployments/csum/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csum/hubploy.yaml
+++ b/deployments/csum/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csum/hubploy.yaml
+++ b/deployments/csum/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csumb/hubploy.yaml
+++ b/deployments/csumb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csumb/hubploy.yaml
+++ b/deployments/csumb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csumb/hubploy.yaml
+++ b/deployments/csumb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csumb/hubploy.yaml
+++ b/deployments/csumb/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csus/hubploy.yaml
+++ b/deployments/csus/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csus/hubploy.yaml
+++ b/deployments/csus/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csus/hubploy.yaml
+++ b/deployments/csus/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csus/hubploy.yaml
+++ b/deployments/csus/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/csusj/hubploy.yaml
+++ b/deployments/csusj/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/csusj/hubploy.yaml
+++ b/deployments/csusj/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/csusj/hubploy.yaml
+++ b/deployments/csusj/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/csusj/hubploy.yaml
+++ b/deployments/csusj/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/cuesta/hubploy.yaml
+++ b/deployments/cuesta/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/cuesta/hubploy.yaml
+++ b/deployments/cuesta/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/cuesta/hubploy.yaml
+++ b/deployments/cuesta/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/cuesta/hubploy.yaml
+++ b/deployments/cuesta/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/dvc/hubploy.yaml
+++ b/deployments/dvc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/dvc/hubploy.yaml
+++ b/deployments/dvc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/dvc/hubploy.yaml
+++ b/deployments/dvc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/dvc/hubploy.yaml
+++ b/deployments/dvc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/evc/hubploy.yaml
+++ b/deployments/evc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/evc/hubploy.yaml
+++ b/deployments/evc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/evc/hubploy.yaml
+++ b/deployments/evc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/evc/hubploy.yaml
+++ b/deployments/evc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/folsomlake/hubploy.yaml
+++ b/deployments/folsomlake/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/folsomlake/hubploy.yaml
+++ b/deployments/folsomlake/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/folsomlake/hubploy.yaml
+++ b/deployments/folsomlake/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/folsomlake/hubploy.yaml
+++ b/deployments/folsomlake/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/fresno/hubploy.yaml
+++ b/deployments/fresno/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/fresno/hubploy.yaml
+++ b/deployments/fresno/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/fresno/hubploy.yaml
+++ b/deployments/fresno/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/fresno/hubploy.yaml
+++ b/deployments/fresno/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/jupyter/hubploy.yaml
+++ b/deployments/jupyter/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/jupyter/hubploy.yaml
+++ b/deployments/jupyter/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/jupyter/hubploy.yaml
+++ b/deployments/jupyter/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/jupyter/hubploy.yaml
+++ b/deployments/jupyter/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/lacc/hubploy.yaml
+++ b/deployments/lacc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/lacc/hubploy.yaml
+++ b/deployments/lacc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/lacc/hubploy.yaml
+++ b/deployments/lacc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/lacc/hubploy.yaml
+++ b/deployments/lacc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/ucla/hubploy.yaml
+++ b/deployments/ucla/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/ucla/hubploy.yaml
+++ b/deployments/ucla/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/ucla/hubploy.yaml
+++ b/deployments/ucla/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/ucla/hubploy.yaml
+++ b/deployments/ucla/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/ucsc/hubploy.yaml
+++ b/deployments/ucsc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/ucsc/hubploy.yaml
+++ b/deployments/ucsc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/ucsc/hubploy.yaml
+++ b/deployments/ucsc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/ucsc/hubploy.yaml
+++ b/deployments/ucsc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud

--- a/deployments/usc/hubploy.yaml
+++ b/deployments/usc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
 
 cluster:
   provider: gcloud

--- a/deployments/usc/hubploy.yaml
+++ b/deployments/usc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:ce126dd0db54
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
 
 cluster:
   provider: gcloud

--- a/deployments/usc/hubploy.yaml
+++ b/deployments/usc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0a4e2c8aaaf2
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:0f7527e95cea
 
 cluster:
   provider: gcloud

--- a/deployments/usc/hubploy.yaml
+++ b/deployments/usc/hubploy.yaml
@@ -1,6 +1,6 @@
 images:
   images:
-    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:e405413993af
+    - name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image:623e4364306b
 
 cluster:
   provider: gcloud


### PR DESCRIPTION
@sean-morris please test out the `datascience` package on any staging hub before merging this.  thanks!

edit:  the 2nd and 3rd PRs (#274 and #275 ) are safe to merge to prod post-testing.  #274 was just a couple of minor python package bumps + repo2docker version pin and #275 and #276 removes the 'copy shareable link' option in the context menu.