### PR TITLE
bump node placeholder

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: node-placeholder-scaler
-    version: 0.0.1-0.dev.git.1.h167f609
+    version: 0.0.1-0.dev.git.1.ha08cff2
     repository: oci://us-central1-docker.pkg.dev/cal-icor-hubs/helm-charts
   - name: prometheus-statsd-exporter
     version: 0.11.0


### PR DESCRIPTION
thanks to some dev work by @yijunge-ucb (https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/pull/8) and some associated (minor) bug fixes (https://github.com/cal-icor/jupyterhub-k8s-node-placeholder/pull/21 https://github.com/cal-icor/jupyterhub-k8s-node-placeholder/pull/22), now we  have a node placeholder deployment that will automagically scale down when the existing nodes have enough in the way of resources!

this could save us up to ~$300/month per user pool (we currently have only one pool) by not having extra unused nodes lying around during peak times.  :)