### PR TITLE
bringing workshop hub config to reasonable level

### DIFF
--- a/deployments/jupyter/config/prod.yaml
+++ b/deployments/jupyter/config/prod.yaml
@@ -18,14 +18,7 @@ jupyterhub:
     db:
       pvc:
         # This also holds logs
-        storage: 80Gi
-    resources:
-      requests:
-        # DataHub often takes up a full CPU now, so let's guarantee it at least that
-        cpu: 1
-        memory: 1Gi
-      limits:
-        memory: 2Gi
+        storage: 4Gi
   scheduling:
     userPlaceholder:
       enabled: false


### PR DESCRIPTION
these settings were left over from the datahub days, and are overkill for a low-usage and low-user count hub.