### PR TITLE
merging 349/350/351/352/355 to prod

### DIFF
--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -62,7 +62,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
-      tag: e7be46547a89
+      tag: 1557cf80849e
     extraFiles:
       # DH-216
       remove-exporters:

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -62,7 +62,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
-      tag: 3f28a1fd6761
+      tag: 5b65bd99be32
     extraFiles:
       # DH-216
       remove-exporters:

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -62,7 +62,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
-      tag: 1557cf80849e
+      tag: 47e75477704b
     extraFiles:
       # DH-216
       remove-exporters:

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -62,7 +62,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
-      tag: 5b65bd99be32
+      tag: e7be46547a89
     extraFiles:
       # DH-216
       remove-exporters:

--- a/deployments/csumb/config/prod.yaml
+++ b/deployments/csumb/config/prod.yaml
@@ -3,6 +3,10 @@ nfsPVC:
     shareName: shares/csumb/prod
 
 jupyterhub:
+  singleuser:
+    image:
+      name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
+      tag: 22b0062053ef
   ingress:
     enabled: true
     hosts:

--- a/deployments/csumb/config/staging.yaml
+++ b/deployments/csumb/config/staging.yaml
@@ -4,11 +4,9 @@ nfsPVC:
 
 jupyterhub:
   singleuser:
-    defaultUrl: "/rstudio"
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
-      tag: 47e75477704b
-
+      tag: 8bc650528323
   scheduling:
     userScheduler:
       replicas: 1

--- a/deployments/csumb/config/staging.yaml
+++ b/deployments/csumb/config/staging.yaml
@@ -3,6 +3,12 @@ nfsPVC:
     shareName: shares/csumb/staging
 
 jupyterhub:
+  singleuser:
+    defaultUrl: "/rstudio"
+    image:
+      name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
+      tag: 47e75477704b
+
   scheduling:
     userScheduler:
       replicas: 1


### PR DESCRIPTION
this will clean out our `staging` queue, as well as pin the image hashes for csumb's staging and prod deployments