### PR TITLE
lower threshold for new placeholder pods to be spawned

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -191,6 +191,9 @@ node-placeholder-scaler:
 
   calendarTimezone: "America/Los_Angeles"
 
+  cpuThreshold: 0.25
+  memoryThreshold: 0.25
+
   nodePools:
     # short name of the node pool, used in the calendar event description
     base:


### PR DESCRIPTION
let's move these from the default (20%) to something less restrictive (25%).