### PR TITLE
move k8s services to the new node pools

### DIFF
--- a/deployments/chicostate/config/common.yaml
+++ b/deployments/chicostate/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csub/config/common.yaml
+++ b/deployments/csub/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csueb/config/common.yaml
+++ b/deployments/csueb/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -15,15 +15,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csufresno/config/common.yaml
+++ b/deployments/csufresno/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csulb/config/common.yaml
+++ b/deployments/csulb/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csum/config/common.yaml
+++ b/deployments/csum/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csun/config/common.yaml
+++ b/deployments/csun/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csusj/config/common.yaml
+++ b/deployments/csusj/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/csusonoma/config/common.yaml
+++ b/deployments/csusonoma/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/cuesta/config/common.yaml
+++ b/deployments/cuesta/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/demo/config/common.yaml
+++ b/deployments/demo/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         admin_access: true

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -16,15 +16,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -16,11 +16,11 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
       resources:
         requests:
           # FIXME: We want no guarantees here!!!
@@ -32,7 +32,7 @@ jupyterhub:
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         admin_access: true

--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -21,14 +21,6 @@ jupyterhub:
     chp:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool-2025-12-22
-      resources:
-        requests:
-          # FIXME: We want no guarantees here!!!
-          # This is lowest possible value
-          cpu: 0.001
-          memory: 3Gi
-        limits:
-          memory: 3Gi
 
   hub:
     nodeSelector:

--- a/deployments/sage/config/common.yaml
+++ b/deployments/sage/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         admin_access: true

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: {{cookiecutter.authenticator_class}}

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -17,15 +17,15 @@ jupyterhub:
   scheduling:
     userScheduler:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
   proxy:
     chp:
       nodeSelector:
-        hub.jupyter.org/pool-name: core-pool
+        hub.jupyter.org/pool-name: core-pool-2025-12-22
 
   hub:
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     config:
       JupyterHub:
         authenticator_class: cilogon

--- a/hub/templates/home-dirsize-reporter.yaml
+++ b/hub/templates/home-dirsize-reporter.yaml
@@ -33,7 +33,7 @@ spec:
         component: shared-dirsize-metrics
     spec:
       nodeSelector:
-        hub.jupyter.org/pool-name: support-pool 
+        hub.jupyter.org/pool-name: support-pool-2025-12-22 
         
       containers:
         - name: dirsize-exporter

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,12 +1,12 @@
 cert-manager:
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool
+    hub.jupyter.org/pool-name: support-pool-2025-12-22
   cainjector:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool
+      hub.jupyter.org/pool-name: support-pool-2025-12-22
   webhook:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool
+      hub.jupyter.org/pool-name: support-pool-2025-12-22
   # # Our cluster-internal DNS seems to cache aggressively in
   # # some cases. The cache is also more likely to be warm,
   # # causing issues when cert-manager tries to verify
@@ -32,7 +32,7 @@ ingress-nginx:
     # Best effort guess on resource needs
     # We overprovision a little - issues here cause a full cluster outage
     nodeSelector:
-      hub.jupyter.org/pool-name: core-pool
+      hub.jupyter.org/pool-name: core-pool-2025-12-22
     replicaCount: 3
     resources:
       limits:
@@ -77,13 +77,13 @@ prometheus:
   # make sure we collect metrics on pods by app/component at least
   kube-state-metrics:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool
+      hub.jupyter.org/pool-name: support-pool-2025-12-22
     metricLabelsAllowlist:
       - pods=[app,component,hub.jupyter.org/username,app.kubernetes.io/component]
       - nodes=[*]
   server:
     nodeSelector:
-      hub.jupyter.org/pool-name: prometheus-pool
+      hub.jupyter.org/pool-name: prometheus-pool-2025-12-22
     resources:
       # Without this, prometheus can easily starve users
       requests:
@@ -109,7 +109,7 @@ prometheus:
 grafana:
   assertNoLeakedSecrets: false
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool
+    hub.jupyter.org/pool-name: support-pool-2025-12-22
   deploymentStrategy:
     type: Recreate
 
@@ -171,7 +171,7 @@ grafana:
 
 prometheus-statsd-exporter:
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool
+    hub.jupyter.org/pool-name: support-pool-2025-12-22
   service:
     annotations:
       prometheus.io/scrape: "true"

--- a/vendor/google/deployments/gke/configs/support_pool.yaml
+++ b/vendor/google/deployments/gke/configs/support_pool.yaml
@@ -2,10 +2,10 @@ imports:
   - path: ../templates/user_pool_template.py
 
 resources:
-  - name: support-pool-2025-12-22
+  - name: support-pool
     type: ../templates/support_pool_template.py
     properties:
-      poolName: support-pool-2025-12-22
+      poolName: support-pool
       clusterName: cal-icor-spring-2025
       region: us-central1
       dateSuffix: '2024-11-04'

--- a/vendor/google/deployments/gke/configs/support_pool.yaml
+++ b/vendor/google/deployments/gke/configs/support_pool.yaml
@@ -2,10 +2,10 @@ imports:
   - path: ../templates/user_pool_template.py
 
 resources:
-  - name: support-pool
+  - name: support-pool-2025-12-22
     type: ../templates/support_pool_template.py
     properties:
-      poolName: support-pool
+      poolName: support-pool-2025-12-22
       clusterName: cal-icor-spring-2025
       region: us-central1
       dateSuffix: '2024-11-04'


### PR DESCRIPTION
resolves https://github.com/cal-icor/cal-icor-hubs/issues/326

```
(dh) ➜  cal-icor-hubs git:(rightsize-node-pools) ✗ grep -lr core-pool | xargs sed -i -e 's,core-pool,core-pool-2025-12-22,g'
(dh) ➜  cal-icor-hubs git:(rightsize-node-pools) ✗ grep -lr prometheus-pool | xargs sed -i -e 's,prometheus-pool,prometheus-pool-2025-12-22,g'
(dh) ➜  cal-icor-hubs git:(rightsize-node-pools) ✗ grep -lr support-pool | xargs sed -i -e 's,support-pool,support-pool-2025-12-22,g'
```