### PR TITLE
normalize ram allocation for users by setting the `limit` and `guarantee` to be equal values

### DIFF
--- a/deployments/chicostate/config/common.yaml
+++ b/deployments/chicostate/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csub/config/common.yaml
+++ b/deployments/csub/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csueb/config/common.yaml
+++ b/deployments/csueb/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csufresno/config/common.yaml
+++ b/deployments/csufresno/config/common.yaml
@@ -77,7 +77,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csulb/config/common.yaml
+++ b/deployments/csulb/config/common.yaml
@@ -86,7 +86,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csum/config/common.yaml
+++ b/deployments/csum/config/common.yaml
@@ -77,7 +77,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -88,7 +88,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csun/config/common.yaml
+++ b/deployments/csun/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csusj/config/common.yaml
+++ b/deployments/csusj/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/csusonoma/config/common.yaml
+++ b/deployments/csusonoma/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/cuesta/config/common.yaml
+++ b/deployments/cuesta/config/common.yaml
@@ -73,7 +73,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -101,7 +101,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
   #custom:

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -75,7 +75,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -21,14 +21,6 @@ jupyterhub:
     chp:
       nodeSelector:
         hub.jupyter.org/pool-name: core-pool
-      resources:
-        requests:
-          # FIXME: We want no guarantees here!!!
-          # This is lowest possible value
-          cpu: 0.001
-          memory: 3Gi
-        limits:
-          memory: 3Gi
 
   hub:
     nodeSelector:
@@ -108,7 +100,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 1G
+      guarantee: 2G
       limit: 2G
 
   #custom:

--- a/deployments/sage/config/common.yaml
+++ b/deployments/sage/config/common.yaml
@@ -81,7 +81,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -94,7 +94,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -77,7 +77,7 @@ jupyterhub:
       #     subPath: _shared
       #     readOnly: true
     memory:
-      guarantee: 512M
+      guarantee: 1G
       limit: 1G
 
 


### PR DESCRIPTION
this means that all users will absolutely have the same amount of ram at all times.