### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -2,6 +2,9 @@
 # image for any or all hubs has has changed, and if so, deploy accordingly.
 #
 name: Deploy staging and prod hubs
+permissions:
+  contents: read
+  pull-requests: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cal-icor/cal-icor-hubs/security/code-scanning/4](https://github.com/cal-icor/cal-icor-hubs/security/code-scanning/4)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in this workflow using a `permissions:` block, instead of relying on repository defaults. Since both jobs only need to read repository contents and pull request metadata (to get labels on the merge commit), we can safely set `contents: read` and `pull-requests: read` at the workflow level, which applies to both jobs.

The single best change with minimal impact is to add a root‑level `permissions` block directly under the existing `name:` field in `.github/workflows/deploy-hubs.yaml`. No existing steps need modification, and both jobs will inherit these reduced permissions automatically. Concretely, in that file, after line 4 (`name: Deploy staging and prod hubs`), insert:

```yaml
permissions:
  contents: read
  pull-requests: read
```

No additional imports, methods, or other definitions are required; this is purely a YAML configuration change to the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
