### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prevent-prod-merges.yaml
+++ b/.github/workflows/prevent-prod-merges.yaml
@@ -1,5 +1,8 @@
 name: Only allow staging -> prod & !prod -> staging merges
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cal-icor/cal-icor-hubs/security/code-scanning/1](https://github.com/cal-icor/cal-icor-hubs/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block so that the `GITHUB_TOKEN` has the minimal necessary rights. Since this workflow only evaluates branch names and exits with success/failure, it does not need to write anything or call the GitHub API, so we can safely set all permissions to `read-all` or, more strictly, `contents: read` if we want to be very specific. GitHub’s recommended minimal safe default for jobs that don’t require write is `permissions: read-all`.

The best minimal change without altering behavior is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). This will apply to all jobs in this workflow (there is only `check-branch`) and ensure the token is read‑only. For this file, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys. No additional imports, tools, or other code are needed, and no existing lines need modification beyond shifting the `on:` block down by two lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
