### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-support.yaml
+++ b/.github/workflows/deploy-support.yaml
@@ -1,5 +1,7 @@
 name: Deploy support helm chart
 # use echo ${VAR##*: } to get the value of a variable that is a string with a colon in it
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cal-icor/cal-icor-hubs/security/code-scanning/3](https://github.com/cal-icor/cal-icor-hubs/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block to the workflow or the specific job so that the `GITHUB_TOKEN` has only the minimum required scopes. For this workflow, the job uses the token for reading repository metadata and labels and checking out code, which only requires `contents: read` (and, if label access is required via the GitHub API, the built-in `metadata` permission which defaults to `read` and does not need to be declared). There is no need for write permissions.

The single best fix without changing existing behavior is to add a workflow-level `permissions` block directly under the `name:` declaration so that it applies to all jobs, including `deploy`. We will set `permissions: contents: read`, which is compatible with `actions/checkout` and should be sufficient for `irby/get-labels-on-push` since it only reads data. No other files or imports are involved; we only modify `.github/workflows/deploy-support.yaml` by inserting this block after line 1.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
