### PR TITLE
test `get-labels-on-push` RC

### DIFF
--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -70,67 +70,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -70,67 +70,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -82,67 +82,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/csusonoma/config/common.yaml
+++ b/deployments/csusonoma/config/common.yaml
@@ -70,67 +70,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/demo/config/common.yaml
+++ b/deployments/demo/config/common.yaml
@@ -51,8 +51,6 @@ jupyterhub:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - sean.smorris
-          - jonathanferrari@berkeley.edu
-          - jonathanferrari
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/java-user-image
@@ -78,67 +76,11 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
+      extraVolumeMounts:
+        - name: home
+          mountPath: /home/jovyan/shared
+          subPath: _shared
+          readOnly: true
     memory:
       guarantee: 2G
       limit: 2G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -95,48 +95,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -69,67 +69,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -72,11 +72,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 2G
       limit: 2G

--- a/deployments/sage/config/common.yaml
+++ b/deployments/sage/config/common.yaml
@@ -75,67 +75,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -88,11 +88,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -70,67 +70,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -71,67 +71,6 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      # extraVolumeMounts:
-      #   - name: home
-      #     mountPath: /home/jovyan/shared
-      #     subPath: _shared
-      #     readOnly: true
     memory:
       guarantee: 1G
       limit: 1G
-
-
-  # This is under hub/config but got in the way when I 
-  # use the template to programmatically add an idp.
-  # loadRoles:
-      # cal-icor staff
-      # cal-icor-staff:
-        # description: Enable admin for cal-icor staff
-        # this role provides permissions to...
-        # scopes:
-        #   - admin-ui
-        #   - admin:groups
-        #   - admin:users
-        #   - admin:servers
-        #   - read:roles
-        #   - read:hub
-        #   - access:servers
-        # this role will be assigned to...
-        # groups:
-        #   - course::1524699::group::all-admins
-  #custom:
-  #  group_profiles:
-  #
-  #    # Example: increase memory for everyone affiliated with a course.
-  #
-  #    # Name of Class 100, Fall '22; requested in #98765
-  #    course::123456:
-  #      mem_limit: 4096M
-  #      mem_guarantee: 2048M
-  #
-  #    # Example: grant admin rights to course staff.
-  #    # Enrollment types returned by the Canvas API are `teacher`,
-  #    # `student`, `ta`, `observer`, and `designer`.
-  #    # https://canvas.instructure.com/doc/api/enrollments.html
-  #
-  #    # Some other class 200, Spring '23; requested in #98776
-  #    course::234567::enrollment_type::teacher:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #    course::234567::enrollment_type::ta:
-  #      mem_limit: 2096M
-  #      mem_guarantee: 2048M
-  #
-  #
-  #    # Example: a fully specified CanvasOAuthenticator group name.
-  #    # This could be useful for temporary resource bumps where the
-  #    # instructor could add people to groups in the bCourses UI. This
-  #    # would benefit from the ability to read resource bumps from
-  #    # jupyterhub's properties. (attributes in the ORM)
-  #
-  #    # Name of Class 100, Fall '22; requested in #98770
-  #    course::123456::group::lab4-bigdata:
-  #      - mountPath: /home/rstudio/.ssh
-  #        name: home
-  #        subPath: _some_directory/_ssh
-  #        readOnly: true

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -192,7 +192,7 @@ node-placeholder-scaler:
   calendarTimezone: "America/Los_Angeles"
 
   cpuThreshold: 0.25
-  memoryThreshold: 0.36
+  memoryThreshold: 0.35
   scalingStrategy: "mem" # Options: cpu, mem, balanced (default)
   
   nodePools:


### PR DESCRIPTION
we'll test our support and some hub deployment helm charts here.

support chart was modified by tweaking the memory threshold for the node-placeholder.

hub charts modified by cleanup old (and at times, confusing) comments.

ref: https://github.com/irby/get-labels-on-push/issues/7