### PR TITLE
raise node placeholder memory threshold

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -192,7 +192,7 @@ node-placeholder-scaler:
   calendarTimezone: "America/Los_Angeles"
 
   cpuThreshold: 0.25
-  memoryThreshold: 0.35
+  memoryThreshold: 0.40 # set this pretty high to avoid overloading nodes and get new ones spun up earlier
   scalingStrategy: "mem" # Options: cpu, mem, balanced (default)
   
   nodePools:


### PR DESCRIPTION
this should spin up placeholder nodes earlier, and (hopefully) reduce the number of false pages.