### PR TITLE
lowering the memory threshold for the node placeholder scaler

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -192,7 +192,7 @@ node-placeholder-scaler:
   calendarTimezone: "America/Los_Angeles"
 
   cpuThreshold: 0.25
-  memoryThreshold: 0.40 # set this pretty high to avoid overloading nodes and get new ones spun up earlier
+  memoryThreshold: 0.30 # set this pretty high to avoid overloading nodes and get new ones spun up earlier
   scalingStrategy: "mem" # Options: cpu, mem, balanced (default)
   
   nodePools:


### PR DESCRIPTION
after comparing our node usage graphs over the past week to those from the fall, i'm seeing that we're continually running w/at least 1-2 extra nodes than before.

i think we can lower the threshold from 40% to 30% w/o causing any new or worsening delay in user spawns during a scaling event.

one thing to also consider is that in #467 we now have the user's memory limits and guarantees to both be 1G, and before that it was 512M/1G guarantee/limit.  this means we can pack fewer users on a node, but each user is guaranteed to get 1G of ram.  i *may* consider reverting this change in the near future, after i spend more time monitoring users' memory usage patterns over time.