### PR TITLE
moving support pool to smaller node

### DIFF
--- a/hub/templates/home-dirsize-reporter.yaml
+++ b/hub/templates/home-dirsize-reporter.yaml
@@ -33,7 +33,7 @@ spec:
         component: shared-dirsize-metrics
     spec:
       nodeSelector:
-        hub.jupyter.org/pool-name: support-pool-2025-12-22 
+        hub.jupyter.org/pool-name: support-pool-2026-02-12
         
       containers:
         - name: dirsize-exporter

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,12 +1,12 @@
 cert-manager:
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2025-12-22
+    hub.jupyter.org/pool-name: support-pool-2026-02-12
   cainjector:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool-2025-12-22
+      hub.jupyter.org/pool-name: support-pool-2026-02-12
   webhook:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool-2025-12-22
+      hub.jupyter.org/pool-name: support-pool-2026-02-12
   # # Our cluster-internal DNS seems to cache aggressively in
   # # some cases. The cache is also more likely to be warm,
   # # causing issues when cert-manager tries to verify
@@ -77,7 +77,7 @@ prometheus:
   # make sure we collect metrics on pods by app/component at least
   kube-state-metrics:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool-2025-12-22
+      hub.jupyter.org/pool-name: support-pool-2026-02-12
     metricLabelsAllowlist:
       - pods=[app,component,hub.jupyter.org/username,app.kubernetes.io/component]
       - nodes=[*]
@@ -110,7 +110,7 @@ prometheus:
 grafana:
   assertNoLeakedSecrets: false
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2025-12-22
+    hub.jupyter.org/pool-name: support-pool-2026-02-12
   deploymentStrategy:
     type: Recreate
 
@@ -172,7 +172,7 @@ grafana:
 
 prometheus-statsd-exporter:
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2025-12-22
+    hub.jupyter.org/pool-name: support-pool-2026-02-12
   service:
     annotations:
       prometheus.io/scrape: "true"


### PR DESCRIPTION
i mistakenly put the support pool on a `n2-standard-8` node pool instead of `n2-standard-4`.  this pr rectifies that situation.