### PR TITLE
add a list of image repos

### DIFF
--- a/configs/image-repos.txt
+++ b/configs/image-repos.txt
@@ -1,4 +1,6 @@
 git@github.com:cal-icor/base-user-image.git
+git@github.com:cal-icor/cloudbank-etsu-image.git
+git@github.com:cal-icor/cloudbank-umd-image.git
 git@github.com:cal-icor/csumb-user-image.git
 git@github.com:cal-icor/gpu-demo.git
 git@github.com:cal-icor/java-user-image.git

--- a/configs/repos.txt
+++ b/configs/repos.txt
@@ -1,0 +1,9 @@
+git@github.com:cal-icor/base-user-image.git
+git@github.com:cal-icor/csumb-user-image.git
+git@github.com:cal-icor/gpu-demo.git
+git@github.com:cal-icor/java-user-image.git
+git@github.com:cal-icor/rstudio-user-image.git
+git@github.com:cal-icor/sagemath-user-image.git
+git@github.com:cal-icor/workshop-cpu-image.git
+git@github.com:cal-icor/workshop-gpu-image.git
+git@github.com:cal-icor/workshop-user-image.git


### PR DESCRIPTION
since our number of repos is growing, i will now start using the [manage-repos](https://github.com/berkeley-dsep-infra/manage-repos) tool i created for the datahub team for bulk package updates and image changes.

@sean-morris i'm pretty sure that this list is complete but would like confirmation.  thanks!