### PR TITLE
disable dirsize reporter for rstudio deployment and all staging hubs

### DIFF
--- a/deployments/chicostate/config/staging.yaml
+++ b/deployments/chicostate/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/chicostate/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csub/config/staging.yaml
+++ b/deployments/csub/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csub/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csueb/config/staging.yaml
+++ b/deployments/csueb/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csueb/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csuf/config/staging.yaml
+++ b/deployments/csuf/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csuf/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csufresno/config/staging.yaml
+++ b/deployments/csufresno/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csufresno/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csula/config/staging.yaml
+++ b/deployments/csula/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csula/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csulb/config/staging.yaml
+++ b/deployments/csulb/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csulb/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csum/config/staging.yaml
+++ b/deployments/csum/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csum/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csumb/config/staging.yaml
+++ b/deployments/csumb/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csumb/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   # singleuser:

--- a/deployments/csun/config/staging.yaml
+++ b/deployments/csun/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csun/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csus/config/staging.yaml
+++ b/deployments/csus/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csus/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csusj/config/staging.yaml
+++ b/deployments/csusj/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csusj/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/csusonoma/config/staging.yaml
+++ b/deployments/csusonoma/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/csusonoma/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/demo/config/staging.yaml
+++ b/deployments/demo/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/demo/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/dvc/config/staging.yaml
+++ b/deployments/dvc/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/dvc/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   singleuser:

--- a/deployments/folsomlake/config/staging.yaml
+++ b/deployments/folsomlake/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/folsomlake/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/fresno/config/staging.yaml
+++ b/deployments/fresno/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/fresno/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/jupyter/config/staging.yaml
+++ b/deployments/jupyter/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/jupyter/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/rstudio/config/common.yaml
+++ b/deployments/rstudio/config/common.yaml
@@ -2,6 +2,8 @@ nfsPVC:
   enabled: true
   nfs:
     serverIP: 10.183.114.2
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   custom:

--- a/deployments/rstudio/config/staging.yaml
+++ b/deployments/rstudio/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/jupyter/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/sage/config/staging.yaml
+++ b/deployments/sage/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/sage/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/ucsc/config/staging.yaml
+++ b/deployments/ucsc/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/ucsc/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:

--- a/deployments/usc/config/staging.yaml
+++ b/deployments/usc/config/staging.yaml
@@ -1,6 +1,8 @@
 nfsPVC:
   nfs:
     shareName: shares/usc/staging
+  dirsizeReporter:
+    enabled: false
 
 jupyterhub:
   scheduling:


### PR DESCRIPTION
since the ultimate goal is to have our rstudio deployments sharing the same nfs mount as the python/jupyterlab hubs they're running in parallel with, we don't need to have the reporter running.

we'll also disable all dirsize reporting for staging hubs -- we really don't care too much about them and they are rarely used except for acceptance testing