### PR TITLE
support deploying new hubs to existing filestore mounts, and/or using custom images

### DIFF
--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -4,6 +4,7 @@
 image_name: # leave blank for base user image. full image path e.g. us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
 image_tag: # leave blank for base user image.  this is the short image tag created by repo2docker, e.g. 7509a8e7435f
 deployment_type: python-base # if not included, defaults to python-base.  other options are rstudio-base
+hub_name: dns-valid-hub-name
 hub_filestore_instance: shared-filestore
 hub_filestore_ip: 10.183.114.2
 hub_filestore_mount_path: # leave blank to use hub_name as the default mount path on the filestore, otherwise specify the shared mount path for this hub on the filestore, e.g. csumb

--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -1,8 +1,8 @@
 # This is an example of a configuration file for a JupyterHub deployment.
 # This file should be copied to <name of deployment>.yaml and kept in the
 # _deploy_configs directory.
-image_name: # leave blank for base user image. full image path e.g. us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
-image_tag: # leave blank for base user image.  this is the short image tag created by repo2docker, e.g. 7509a8e7435f
+image_name: # remove or leave blank for base user image. full image path e.g. us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
+image_tag: # remove or leave blank for base user image.  this is the short image tag created by repo2docker, e.g. 7509a8e7435f
 deployment_type: python-base # if not included, defaults to python-base.  other options are rstudio-base
 hub_name: dns-valid-hub-name
 hub_filestore_instance: shared-filestore

--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -3,7 +3,7 @@
 # _deploy_configs directory.
 image_name: # leave blank for base user image. full image path e.g. us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
 image_tag: # leave blank for base user image.  this is the short image tag created by repo2docker, e.g. 7509a8e7435f
-hub_name: 
+deployment_type: python-base # if not included, defaults to python-base.  other options are rstudio-base
 hub_filestore_instance: shared-filestore
 hub_filestore_ip: 10.183.114.2
 hub_filestore_mount_path: # leave blank to use hub_name as the default mount path on the filestore, otherwise specify the shared mount path for this hub on the filestore, e.g. csumb

--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -18,11 +18,7 @@ staging:
   client: 
   secret: 
 admin_emails:
-  - jedwin321@berkeley.edu
-  - ericvd@berkeley.edu
-  - sean.smorris@berkeley.edu
-  - sknapp@berkeley.edu
-
+  - 
 authenticator_class: cilogon # This is either cilogon or github
 authenticator_class_instance: "CILogonOAuthenticator" # This is either "CILogonOAuthenticator" or "GitHubOAuthenticator"
 idp_url: "" # cilogon only e.g.  http://login.microsoftonline.com/common/oauth2/v2.0/authorize

--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -2,7 +2,7 @@
 # This file should be copied to <name of deployment>.yaml and kept in the
 # _deploy_configs directory.
 image_name: # leave blank for base user image. full image path e.g. us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
-image_tag: # leave blank for base user image.  this is the short image path, e.g. 7509a8e7435f
+image_tag: # leave blank for base user image.  this is the short image tag created by repo2docker, e.g. 7509a8e7435f
 hub_name: 
 hub_filestore_instance: shared-filestore
 hub_filestore_ip: 10.183.114.2

--- a/_deploy_configs/institution-example.yaml
+++ b/_deploy_configs/institution-example.yaml
@@ -1,9 +1,12 @@
 # This is an example of a configuration file for a JupyterHub deployment.
 # This file should be copied to <name of deployment>.yaml and kept in the
 # _deploy_configs directory.
+image_name: # leave blank for base user image. full image path e.g. us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
+image_tag: # leave blank for base user image.  this is the short image path, e.g. 7509a8e7435f
 hub_name: 
 hub_filestore_instance: shared-filestore
 hub_filestore_ip: 10.183.114.2
+hub_filestore_mount_path: # leave blank to use hub_name as the default mount path on the filestore, otherwise specify the shared mount path for this hub on the filestore, e.g. csumb
 institution: 
 institution_url: 
 institution_logo_url: 
@@ -15,7 +18,11 @@ staging:
   client: 
   secret: 
 admin_emails:
-  - 
+  - jedwin321@berkeley.edu
+  - ericvd@berkeley.edu
+  - sean.smorris@berkeley.edu
+  - sknapp@berkeley.edu
+
 authenticator_class: cilogon # This is either cilogon or github
 authenticator_class_instance: "CILogonOAuthenticator" # This is either "CILogonOAuthenticator" or "GitHubOAuthenticator"
 idp_url: "" # cilogon only e.g.  http://login.microsoftonline.com/common/oauth2/v2.0/authorize

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -17,7 +17,6 @@
     "authenticator_class": "valid-auth-class",
     "authenticator_class_instance": "valid-auth-instance",
     "idp_url": "https://idp.example.edu",
-    "idp": "example.edu",
     "admin_emails": "",
     "client_id_staging": "valid-client-id-staging",
     "client_secret_staging": "valid-client-secret-staging",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "image_name": "/path/to/image",
     "image_tag": "image-tag",
-    "deployment_type": "",
+    "hub_type": "python-base",
     "hub_name": "dns-valid-hub-name",
     "institution": "full-name-of-institution",
     "institution_url": "https://example.edu",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -1,6 +1,7 @@
 {
     "image_name": "/path/to/image",
     "image_tag": "image-tag",
+    "deployment_type": "python-base",
     "hub_name": "dns-valid-hub-name",
     "institution": "full-name-of-institution",
     "institution_url": "https://example.edu",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "image_name": "/path/to/image",
     "image_tag": "image-tag",
-    "deployment_type": "python-base",
+    "deployment_type": "",
     "hub_name": "dns-valid-hub-name",
     "institution": "full-name-of-institution",
     "institution_url": "https://example.edu",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -1,4 +1,6 @@
 {
+    "image_name": "/path/to/image",
+    "image_tag": "image-tag",
     "hub_name": "dns-valid-hub-name",
     "institution": "full-name-of-institution",
     "institution_url": "https://example.edu",
@@ -9,6 +11,7 @@
     "pool_name": "base-pool",
     "hub_filestore_instance": "shared-filestore",
     "hub_filestore_ip": "10.183.114.2",
+    "hub_filestore_mount_path": "institution-shared-filestore",
     "hub_filestore_share": "shares",
     "hub_filestore_capacity": "1T",
     "authenticator_class": "valid-auth-class",

--- a/deployments/template/cookiecutter.json
+++ b/deployments/template/cookiecutter.json
@@ -1,6 +1,6 @@
 {
-    "image_name": "/path/to/image",
-    "image_tag": "image-tag",
+    "image_name": "",
+    "image_tag": "",
     "hub_type": "python-base",
     "hub_name": "dns-valid-hub-name",
     "institution": "full-name-of-institution",

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -2,7 +2,7 @@ nfsPVC:
   enabled: true
   nfs:
     serverIP: {{cookiecutter.hub_filestore_ip}}
-  {% if cookiecutter.deployment_type == "rstudio-base" %}
+  {% if cookiecutter.hub_type == "rstudio-base" %}
   dirsizeReporter:
     enabled: false
   {% endif %}
@@ -78,7 +78,7 @@ jupyterhub:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
       tag: 7509a8e7435f
       {%- endif %}
-    {% if cookiecutter.deployment_type == "rstudio-base" %}
+    {% if cookiecutter.hub_type == "rstudio-base" %}
     defaultUrl: "/rstudio"
     {% endif %}
     extraFiles:
@@ -89,7 +89,7 @@ jupyterhub:
           c.QtPDFExporter.enabled = False
           c.QtPNGExporter.enabled = False
           c.WebPDFExporter.enabled = False
-        {% if cookiecutter.deployment_type == "rstudio-base" %}
+        {% if cookiecutter.hub_type == "rstudio-base" %}
         jupyter-shiny-proxy:
           mountPath: /etc/jupyter/jupyter_server_config.py
           stringData: |
@@ -105,7 +105,7 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
-      {% if cookiecutter.deployment_type == "rstudio-base" %}
+      {% if cookiecutter.hub_type == "rstudio-base" %}
       extraVolumeMounts:
         # RStudio can't write session files to anywhere except ~/.rstudio -
         # only way to change that is by setting $HOME. So instead, we just

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -68,8 +68,13 @@ jupyterhub:
           {%- endfor %}
   singleuser:
     image:
+      {%- if cookiecutter.image_name and cookiecutter.image_name != "" %}
+      name: {{cookiecutter.image_name}}
+      tag: {{cookiecutter.image_tag}}
+      {%- else %}
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
       tag: 7509a8e7435f
+      {%- endif %}
     extraFiles:
       # DH-216
       remove-exporters:

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -2,7 +2,10 @@ nfsPVC:
   enabled: true
   nfs:
     serverIP: {{cookiecutter.hub_filestore_ip}}
-
+  {% if cookiecutter.deployment_type == "rstudio-base" %}
+  dirsizeReporter:
+    enabled: false
+  {% endif %}
 jupyterhub:
   custom:
     homepage:
@@ -75,6 +78,9 @@ jupyterhub:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
       tag: 7509a8e7435f
       {%- endif %}
+    {% if cookiecutter.deployment_type == "rstudio-base" %}
+    defaultUrl: "/rstudio"
+    {% endif %}
     extraFiles:
       # DH-216
       remove-exporters:
@@ -83,6 +89,12 @@ jupyterhub:
           c.QtPDFExporter.enabled = False
           c.QtPNGExporter.enabled = False
           c.WebPDFExporter.enabled = False
+        {% if cookiecutter.deployment_type == "rstudio-base" %}
+        jupyter-shiny-proxy:
+          mountPath: /etc/jupyter/jupyter_server_config.py
+          stringData: |
+            c.JupyterShinyProxy.site_dir = "ShinyApps"
+        {% endif %}
     extraEnv:
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
@@ -93,6 +105,15 @@ jupyterhub:
       static:
         pvcName: home-nfs-v3
         subPath: "{username}"
+      {% if cookiecutter.deployment_type == "rstudio-base" %}
+      extraVolumeMounts:
+        # RStudio can't write session files to anywhere except ~/.rstudio -
+        # only way to change that is by setting $HOME. So instead, we just
+        # bind mount a fresh directory on top of ~/.rstudio!
+        - name: home
+          mountPath: /home/jovyan/.rstudio
+          subPath: '{username}/.r-hub-rstudio'
+    {% endif %}
     memory:
       guarantee: 512M
       limit: 1G

--- a/deployments/template/{{cookiecutter.hub_name}}/config/prod.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/prod.yaml
@@ -1,6 +1,6 @@
 nfsPVC:
   nfs:
-    shareName: {{cookiecutter.hub_filestore_share}}/{{cookiecutter.hub_name}}/prod
+    shareName: {{cookiecutter.hub_filestore_share}}/{{cookiecutter.hub_filestore_mount_path}}/prod
 
 jupyterhub:
   ingress:

--- a/deployments/template/{{cookiecutter.hub_name}}/config/staging.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/staging.yaml
@@ -1,6 +1,6 @@
 nfsPVC:
   nfs:
-    shareName: {{cookiecutter.hub_filestore_share}}/{{cookiecutter.hub_name}}/staging
+    shareName: {{cookiecutter.hub_filestore_share}}/{{cookiecutter.hub_filestore_mount_path}}/staging
   dirsizeReporter:
     enabled: false
 

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -463,7 +463,7 @@ def main(args):
 
     if args.dry_run:
         print(
-            "Performing a dry-run, only the config changes in your repo will be performed, but no remote actions taken."
+            "Performing a dry-run, only the config changes in your repo will be performed, but no remote actions taken.\n"
         )
 
     create_deployment(
@@ -478,7 +478,7 @@ def main(args):
     print(
         f"\nDeployment for {config['hub_name']} created."
         + "\nDo not forget to create the alerts for the new hub after merging "
-        + "the PR to prod. The instructions for that are found here: "
+        + "the PR to prod. The instructions for that are found here: \n"
         + "https://docs.cal-icor.org/new-hub/#create-the-alerts-for-the-new-hub"
     )
 

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -247,7 +247,10 @@ def populate_deployment_config(
     print(f"Generating {config['hub_name']} cookiecutter template.")
 
     # check for overridden hub_filestore_mount_path in the config, if not found, set it to hub_name
-    if "hub_filestore_mount_path" not in config:
+    if (
+        "hub_filestore_mount_path" not in config
+        or not config["hub_filestore_mount_path"]
+    ):
         print(
             f"No hub_filestore_mount_path specified in the config file for {config['hub_name']}. "
             + "Using hub_name as the default hub_filestore_mount_path."

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -267,11 +267,14 @@ def populate_deployment_config(
             + f"as specified in the config file for {config['hub_name']}."
         )
 
+    # Check for overridden image_name and image_tag in the config, if not found, don't set them.
     cookiecutter(
         template=f"{root_path}/deployments/template",
         output_dir=f"{root_path}/deployments",
         no_input=manual_config,
         extra_context={
+            "image_name": config.get("image_name", None),
+            "image_tag": config.get("image_tag", None),
             "hub_name": config["hub_name"],
             "hub_filestore_instance": config["hub_filestore_instance"],
             "hub_filestore_ip": config["hub_filestore_ip"],

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -272,6 +272,7 @@ def populate_deployment_config(
         extra_context={
             "image_name": config["image_name"],
             "image_tag": config["image_tag"],
+            "hub_type": config["hub_type"],
             "hub_name": config["hub_name"],
             "hub_filestore_instance": config["hub_filestore_instance"],
             "hub_filestore_ip": config["hub_filestore_ip"],

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -251,19 +251,16 @@ def populate_deployment_config(
         "hub_filestore_mount_path" not in config
         or not config["hub_filestore_mount_path"]
     ):
-        print(
-            f"No hub_filestore_mount_path specified in the config file for {config['hub_name']}. "
-            + "Using hub_name as the default hub_filestore_mount_path."
-        )
+        print("Using hub_name as the default hub_filestore_mount_path.")
         config["hub_filestore_mount_path"] = config["hub_name"]
     elif config["hub_filestore_mount_path"] != config["hub_name"]:
         print(
-            f"Overriding hub_filestore_mount_path to {config['hub_filestore_mount_path']} "
+            f"Overriding hub_filestore_mount_path to '{config['hub_filestore_mount_path']}' "
             + f"as specified in the config file for {config['hub_name']}."
         )
     else:
         print(
-            f"Using hub_filestore_mount_path of {config['hub_filestore_mount_path']} "
+            f"Using hub_filestore_mount_path of '{config['hub_filestore_mount_path']}' "
             + f"as specified in the config file for {config['hub_name']}."
         )
 
@@ -273,8 +270,8 @@ def populate_deployment_config(
         output_dir=f"{root_path}/deployments",
         no_input=manual_config,
         extra_context={
-            "image_name": config.get("image_name", None),
-            "image_tag": config.get("image_tag", None),
+            "image_name": config["image_name"],
+            "image_tag": config["image_tag"],
             "hub_name": config["hub_name"],
             "hub_filestore_instance": config["hub_filestore_instance"],
             "hub_filestore_ip": config["hub_filestore_ip"],
@@ -346,7 +343,12 @@ def create_remote_dirs(config: dict):
 
 
 def create_deployment(
-    config: dict, github_user: str, root_path: str, manual_config: bool = False
+    config: dict,
+    github_user: str,
+    root_path: str,
+    deploy: bool = False,
+    manual_config: bool = False,
+    dry_run: bool = False,
 ):
     """
     Create a new deployment for an institution using the provided configuration.
@@ -354,46 +356,131 @@ def create_deployment(
         config (dict): The configuration dictionary containing deployment details.
         github_user (str): The GitHub username of the user creating the pull request.
         root_path (str): The parent path where the deployment will be created.
+        deploy (bool): If True, the script will deploy the hub to staging after creating the pull request.
         manual_config (bool): If True, the script will ask for confirmation for each step.
+        dry_run (bool): If True, the script will go through all the steps but not actually make any changes.
     """
+    # The following steps will not be run if the dry_run flag is set, but we
+    # will print out what would have been done.
+
     # Create a feature branch
     branch_name = f"add-{config['hub_name']}-deployment"
-    print(f"Creating feature branch {branch_name}.")
-    create_branch(branch_name, root_path)
+    if dry_run:
+        print(f"Dry run enabled. Would create feature branch {branch_name}.")
+    else:
+        print(f"Creating feature branch {branch_name}.")
+        create_branch(branch_name, root_path)
 
     # create the prod and staging directories on filestore for the new hub
-    print(f"Creating directories for {config['hub_name']} on filestore.")
-    create_remote_dirs(config)
+    if dry_run:
+        print(
+            f"Dry run enabled. Would create directories for {config['hub_name']} on filestore."
+        )
+    else:
+        print(f"Creating directories for {config['hub_name']} on filestore.")
+        create_remote_dirs(config)
 
     # Populate the deployment configuration
     print(f"Populating deployment config for {config['hub_name']}.")
     populate_deployment_config(config, root_path, manual_config)
 
     # Create labels for the new hub
-    print(f"Creating repo and github labels for {config['hub_name']}.")
-    github_label = create_label(config["hub_name"], root_path)
+    if dry_run:
+        print(f"Dry run enabled. Would create GitHub label for {config['hub_name']}.")
+    else:
+        print(f"Creating repo and github labels for {config['hub_name']}.")
+        github_label = create_label(config["hub_name"], root_path)
 
     # Stage and push the new deployment files
-    print(f"Staging and pushing the new deployment files for {config['hub_name']}.")
-    stage_and_push(config["hub_name"], root_path, branch_name)
+    if dry_run:
+        print(
+            f"Dry run enabled. Would stage and push the new deployment files for {config['hub_name']} to branch {branch_name}."
+        )
+    else:
+        print(f"Staging and pushing the new deployment files for {config['hub_name']}.")
+        stage_and_push(config["hub_name"], root_path, branch_name)
 
     # Create a pull request for the new hub
-    print(f"Creating pull request for {config['hub_name']}.")
-    create_pr(github_user, config["hub_name"], branch_name, github_label)
+    if dry_run:
+        print(f"Dry run enabled. Not creating pull request for {config['hub_name']}.")
+    else:
+        print(f"Creating pull request for {config['hub_name']}.")
+        create_pr(github_user, config["hub_name"], branch_name, github_label)
+
+    if deploy:
+        if dry_run:
+            print(
+                f"Dry run enabled. Would deploy the hub to {config['hub_name']}-staging."
+            )
+        else:
+            print(f"Deploying the hub to {config['hub_name']}-staging.")
+            helm.deploy(hub=config["hub_name"], chart="hub", environment="staging")
+            print(f"Deployment to {config['hub_name']}-staging complete.")
 
 
-def main():
+def main(args):
     """
     Main function to parse arguments and create a new deployment for an institution.
     This script should be run from the root cal-icor-hubs directory.
     """
+    # Check if the script is run from the correct directory
+    if Path.cwd() != Path(__file__).resolve().parents[1]:
+        print("Error: This script must be run from the root cal-icor-hubs directory.")
+        exit(1)
 
+    # Check if the _deploy_configs directory exists
+    if not Path(__file__).resolve().parents[1].joinpath("_deploy_configs").exists():
+        print("Error: The _deploy_configs directory does not exist. Please create it.")
+        exit(1)
+
+    # Check if the config file exists
+    if (
+        not Path(__file__)
+        .resolve()
+        .parents[1]
+        .joinpath(f"_deploy_configs/{args.institution_name}.yaml")
+        .exists()
+    ):
+        print(f"Error: The config file {args.institution_name}.yaml does not exist.")
+        exit(1)
+
+    root_path = Path(__file__).resolve().parents[1]
+    file_path = f"{root_path}/_deploy_configs/{args.institution_name}.yaml"
+    with open(file_path) as f:
+        config = yaml.safe_load(f)
+    if not config:
+        print(f"Error loading config for {args.institution_name}.")
+        exit(1)
+
+    if args.dry_run:
+        print(
+            "Performing a dry-run, only the config changes in your repo will be performed, but no remote actions taken."
+        )
+
+    create_deployment(
+        config,
+        args.github_user,
+        root_path,
+        args.deploy,
+        args.manual_config,
+        args.dry_run,
+    )
+
+    print(
+        f"\nDeployment for {config['hub_name']} created."
+        + "\nDo not forget to create the alerts for the new hub after merging "
+        + "the PR to prod. The instructions for that are found here: "
+        + "https://docs.cal-icor.org/new-hub/#create-the-alerts-for-the-new-hub"
+    )
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Create a new deployment for an institution.  This should "
         + "be run from the root cal-icor-hubs directory."
         + "\n\n"
         + "You will also need to fill out the cookiecutter template config "
-        + "in the _deploy_configs/<hubname>.yaml dir in the root of the repo.",
+        + "in the _deploy_configs/<institution_name>.yaml dir in the root of the repo.",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
@@ -424,51 +511,14 @@ def main():
         + "allowing you to manually configure the deployment (eg: custom "
         + "filestore IP, node pool deployment, etc).",
     )
+    parser.add_argument(
+        "--dry-run",
+        "-D",
+        action="store_true",
+        help="If set, the script will go through all the steps but not actually "
+        + "make any changes (eg: not actually creating branches, pushing to "
+        + "GitHub, creating remoter directories or deploying to staging).",
+    )
     args = parser.parse_args()
 
-    # Check if the script is run from the correct directory
-    if Path.cwd() != Path(__file__).resolve().parents[1]:
-        print("Error: This script must be run from the root cal-icor-hubs directory.")
-        exit(1)
-
-    # Check if the _deploy_configs directory exists
-    if not Path(__file__).resolve().parents[1].joinpath("_deploy_configs").exists():
-        print("Error: The _deploy_configs directory does not exist. Please create it.")
-        exit(1)
-
-    # Check if the config file exists
-    if (
-        not Path(__file__)
-        .resolve()
-        .parents[1]
-        .joinpath(f"_deploy_configs/{args.institution_name}.yaml")
-        .exists()
-    ):
-        print(f"Error: The config file {args.institution_name}.yaml does not exist.")
-        exit(1)
-
-    root_path = Path(__file__).resolve().parents[1]
-    file_path = f"{root_path}/_deploy_configs/{args.institution_name}.yaml"
-    with open(file_path) as f:
-        config = yaml.safe_load(f)
-    if not config:
-        print(f"Error loading config for {args.institution_name}.")
-        exit(1)
-
-    create_deployment(config, args.github_user, root_path, args.manual_config)
-
-    if args.deploy:
-        print(f"Deploying the hub to {config['hub_name']}-staging.")
-        helm.deploy(hub=config["hub_name"], chart="hub", environment="staging")
-        print(f"Deployment to {config['hub_name']}-staging complete.")
-
-    print(
-        f"\nDeployment for {config['hub_name']} created."
-        + "\nDo not forget to create the alerts for the new hub after merging "
-        + "the PR to prod. The instructions for that are found here: "
-        + "https://docs.cal-icor.org/content/admin/new_hub.html#create-the-alerts-for-the-new-hub"
-    )
-
-
-if __name__ == "__main__":
-    main()
+    main(args)

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -121,7 +121,7 @@ def create_label(hub_name: str, root_path: str) -> str:
     return github_label
 
 
-def stage_and_push(hub_name: str, root_path: str, branch_name: str):
+def stage_and_push(hub_name: str, root_path: Path, branch_name: str):
     """
     Stage the new deployment files for the hub.
 
@@ -131,22 +131,22 @@ def stage_and_push(hub_name: str, root_path: str, branch_name: str):
         branch_name (str): The name of the branch to push the changes to.
     """
     files_to_add = [
-        f"deployments/{hub_name}/",
-        ".github/labeler.yml",
+        Path(f"deployments/{hub_name}/"),
+        Path(".github/labeler.yml"),
     ]
     for file in files_to_add:
-        print(f"Adding {file} to staging.")
+        print(f"Adding {str(file)} to staging.")
         try:
-            subprocess.check_call(["git", "add", file], cwd=root_path)
+            subprocess.check_call(["git", "add", str(file)], cwd=str(root_path))
         except subprocess.CalledProcessError as e:
-            print(f"Error adding {file} to commit: {e}")
+            print(f"Error adding {str(file)} to commit: {e}")
             exit(1)
 
     commit_message = f"Add {hub_name} deployment."
     print(f"Committing changes for {hub_name} with message {commit_message}.")
     try:
         subprocess.check_call(
-            ["git", "commit", "-m", f"{commit_message}"], cwd=root_path
+            ["git", "commit", "-m", f"{commit_message}"], cwd=str(root_path)
         )
     except subprocess.CalledProcessError as e:
         print(f"Error committing {hub_name}: {e}")
@@ -155,7 +155,7 @@ def stage_and_push(hub_name: str, root_path: str, branch_name: str):
     remote = "origin"
     print(f"Pushing {branch_name} to {remote}")
     try:
-        subprocess.check_call(["git", "push", remote, branch_name], cwd=root_path)
+        subprocess.check_call(["git", "push", remote, branch_name], cwd=str(root_path))
     except subprocess.CalledProcessError as e:
         print(f"Error pushing {branch_name} to {remote}: {e}")
         exit(1)
@@ -196,18 +196,20 @@ def create_pr(github_user: str, hub_name: str, branch_name: str, github_label: s
         exit(1)
 
 
-def create_branch(branch_name: str, root_path: str):
+def create_branch(branch_name: str, root_path: Path):
     """
     Create a new branch in the Git repository.
 
     Args:
         branch_name (str): The name of the new branch to be created.
-        root_path (str): The path to the root directory of the repository.
+        root_path (Path): The path to the root directory of the repository.
     """
     try:
         branch = (
             subprocess.run(
-                ["git", "branch", "--show-current"], cwd=root_path, capture_output=True
+                ["git", "branch", "--show-current"],
+                cwd=str(root_path),
+                capture_output=True,
             )
             .stdout.decode("utf-8")
             .strip()
@@ -223,21 +225,21 @@ def create_branch(branch_name: str, root_path: str):
         )
         exit(1)
     try:
-        subprocess.check_call(["git", "switch", "-c", branch_name], cwd=root_path)
+        subprocess.check_call(["git", "switch", "-c", branch_name], cwd=str(root_path))
     except subprocess.CalledProcessError as e:
         print(f"Error creating branch {branch_name}: {e}")
         exit(1)
 
 
 def populate_deployment_config(
-    config: dict, root_path: str, manual_config: bool = False
+    config: dict, root_path: Path, manual_config: bool = False
 ):
     """
     Populate the deployment configuration file with the provided configuration.
 
     Args:
         config (dict): The configuration dictionary containing deployment details.
-        root_path (str): The path to the root directory of the repository.
+        root_path (Path): The path to the root directory of the repository.
         manual_config (bool): If True, the script will ask for confirmation for each step.
     """
     # Run the cookiecutter to generate the deployment files
@@ -314,10 +316,18 @@ def create_remote_dirs(config: dict):
         config (dict): The configuration dictionary containing deployment details.
     """
     dirs = [
-        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/prod",
-        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/prod/_shared",
-        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/staging",
-        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/staging/_shared",
+        Path(
+            f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/prod"
+        ),
+        Path(
+            f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/prod/_shared"
+        ),
+        Path(
+            f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/staging"
+        ),
+        Path(
+            f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/staging/_shared"
+        ),
     ]
     try:
         subprocess.check_call(
@@ -332,7 +342,7 @@ def create_remote_dirs(config: dict):
                 "[ ! -d '/export/{}/{}' ] && sudo -u ubuntu install -d -o 1000 -g 1000 ".format(
                     config["hub_filestore_instance"], config["hub_filestore_mount_path"]
                 )
-                + " ".join(dirs),
+                + " ".join(str(d) for d in dirs),
             ]
         )
     except subprocess.CalledProcessError as e:
@@ -343,7 +353,7 @@ def create_remote_dirs(config: dict):
 def create_deployment(
     config: dict,
     github_user: str,
-    root_path: str,
+    root_path: Path,
     deploy: bool = False,
     manual_config: bool = False,
     dry_run: bool = False,

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -245,6 +245,25 @@ def populate_deployment_config(
     """
     # Run the cookiecutter to generate the deployment files
     print(f"Generating {config['hub_name']} cookiecutter template.")
+
+    # check for overridden hub_filestore_mount_path in the config, if not found, set it to hub_name
+    if "hub_filestore_mount_path" not in config:
+        print(
+            f"No hub_filestore_mount_path specified in the config file for {config['hub_name']}. "
+            + "Using hub_name as the default hub_filestore_mount_path."
+        )
+        config["hub_filestore_mount_path"] = config["hub_name"]
+    elif config["hub_filestore_mount_path"] != config["hub_name"]:
+        print(
+            f"Overriding hub_filestore_mount_path to {config['hub_filestore_mount_path']} "
+            + f"as specified in the config file for {config['hub_name']}."
+        )
+    else:
+        print(
+            f"Using hub_filestore_mount_path of {config['hub_filestore_mount_path']} "
+            + f"as specified in the config file for {config['hub_name']}."
+        )
+
     cookiecutter(
         template=f"{root_path}/deployments/template",
         output_dir=f"{root_path}/deployments",
@@ -253,6 +272,7 @@ def populate_deployment_config(
             "hub_name": config["hub_name"],
             "hub_filestore_instance": config["hub_filestore_instance"],
             "hub_filestore_ip": config["hub_filestore_ip"],
+            "hub_filestore_mount_path": config["hub_filestore_mount_path"],
             "institution": config["institution"],
             "institution_url": config["institution_url"],
             "institution_logo_url": config["institution_logo_url"],
@@ -285,14 +305,18 @@ def create_remote_dirs(config: dict):
     """
     Create the prod and staging directories on filestore for the new hub.
 
+    Sometimes we want to mount multiple hubs to an existing mount point to
+    share existing user homedirs.  If these shares already exist in Filestore,
+    this command will do nothing.
+
     Args:
         config (dict): The configuration dictionary containing deployment details.
     """
     dirs = [
-        f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/prod",
-        f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/prod/_shared",
-        f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/staging",
-        f"/export/{config['hub_filestore_instance']}/{config['hub_name']}/staging/_shared",
+        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/prod",
+        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/prod/_shared",
+        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/staging",
+        f"/export/{config['hub_filestore_instance']}/{config['hub_filestore_mount_path']}/staging/_shared",
     ]
     try:
         subprocess.check_call(
@@ -304,7 +328,10 @@ def create_remote_dirs(config: dict):
                 "--tunnel-through-iap",
                 "--zone=us-central1-b",
                 "--command",
-                "sudo -u ubuntu install -d -o 1000 -g 1000 " + " ".join(dirs),
+                "[ ! -d '/export/{}/{}' ] && sudo -u ubuntu install -d -o 1000 -g 1000 ".format(
+                    config["hub_filestore_instance"], config["hub_filestore_mount_path"]
+                )
+                + " ".join(dirs),
             ]
         )
     except subprocess.CalledProcessError as e:

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -269,9 +269,21 @@ def populate_deployment_config(
         output_dir=f"{root_path}/deployments",
         no_input=manual_config,
         extra_context={
-            "image_name": config["image_name"],
-            "image_tag": config["image_tag"],
-            "hub_type": config["hub_type"],
+            "image_name": (
+                config["image_name"]
+                if "image_name" in config and config["image_name"]
+                else None
+            ),
+            "image_tag": (
+                config["image_tag"]
+                if "image_tag" in config and config["image_tag"]
+                else None
+            ),
+            "hub_type": (
+                config["hub_type"]
+                if "hub_type" in config and config["hub_type"]
+                else "python-base"
+            ),
             "hub_name": config["hub_name"],
             "hub_filestore_instance": config["hub_filestore_instance"],
             "hub_filestore_ip": config["hub_filestore_ip"],

--- a/scripts/create_deployment.py
+++ b/scripts/create_deployment.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -11,12 +10,12 @@ from cookiecutter.main import cookiecutter
 from hubploy import helm
 
 
-def delete_file(filepath: str):
+def delete_file(filepath: Path):
     """
     Deletes a file from the filesystem.
 
     Args:
-        filepath (str): The path to the file to be deleted.
+        filepath (Path): The path to the file to be deleted.
 
     Raises:
         FileNotFoundError: If the file does not exist.
@@ -24,7 +23,7 @@ def delete_file(filepath: str):
         Exception: For any other errors during file deletion.
     """
     try:
-        os.remove(filepath)
+        filepath.unlink()
         print(f"Deleted file: {filepath}")
     except FileNotFoundError:
         print(f"File not found: {filepath}")
@@ -34,24 +33,25 @@ def delete_file(filepath: str):
         print(f"Error deleting file: {e}")
 
 
-def encrypt_file(input_file: str, output_file: str):
+def encrypt_file(input_file: Path, output_file: Path):
     """
     Encrypts a file using the `sops` command-line tool.
 
     Args:
-        input_file (str): The path to the input file to be encrypted.
-        output_file (str): The path where the encrypted file will be saved.
+        input_file (Path): The path to the input file to be encrypted.
+        output_file (Path): The path where the encrypted file will be saved.
 
     Raises:
         SystemExit: If the input file does not exist or encryption fails.
     """
-    if not os.path.isfile(input_file):
+    if not input_file.is_file():
         print(f"Error: Input file '{input_file}' does not exist.")
         sys.exit(1)
 
     try:
         subprocess.run(
-            ["sops", "--output", output_file, "--encrypt", input_file], check=True
+            ["sops", "--output", str(output_file), "--encrypt", str(input_file)],
+            check=True,
         )
         print(f"Encrypted file saved as: {output_file}")
     except subprocess.CalledProcessError as e:
@@ -73,12 +73,10 @@ def handle_secrets(school_arg: str, env_arg: str):
     """
     print("Secret file generation and encryption beginning.")
     encrypt_file(
-        os.path.join("deployments", school_arg, "secrets", f"{env_arg}.plain.yaml"),
-        os.path.join("deployments", school_arg, "secrets", f"{env_arg}.yaml"),
+        Path(f"deployments/{school_arg}/secrets/{env_arg}.plain.yaml"),
+        Path(f"deployments/{school_arg}/secrets/{env_arg}.yaml"),
     )
-    delete_file(
-        os.path.join("deployments", school_arg, "secrets", f"{env_arg}.plain.yaml")
-    )
+    delete_file(Path(f"deployments/{school_arg}/secrets/{env_arg}.plain.yaml"))
 
 
 def create_label(hub_name: str, root_path: str) -> str:
@@ -91,13 +89,12 @@ def create_label(hub_name: str, root_path: str) -> str:
     Returns:
         str: The GitHub label created for the new hub.
     """
-    labeler_path = os.path.join(root_path, ".github", "labeler.yml")
+    labeler_path = Path(root_path) / ".github" / "labeler.yml"
     hub_label = f"""
 'hub: {hub_name}':
   - 'deployments/{hub_name}/**'
 """.strip()
-    with open(labeler_path, "a") as f:
-        print(hub_label, file=f)
+    labeler_path.write_text(hub_label, append=True)
     print(f"Added {hub_name} to the labeler.yml file.")
 
     # create the github label for the new hub
@@ -446,9 +443,10 @@ def main(args):
         exit(1)
 
     root_path = Path(__file__).resolve().parents[1]
-    file_path = f"{root_path}/_deploy_configs/{args.institution_name}.yaml"
-    with open(file_path) as f:
-        config = yaml.safe_load(f)
+    deployment_config = (
+        Path(root_path) / "_deploy_configs" / f"{args.institution_name}.yaml"
+    )
+    config = yaml.safe_load(deployment_config.read_text())
     if not config:
         print(f"Error loading config for {args.institution_name}.")
         exit(1)


### PR DESCRIPTION
when we deploy the new rstudio hubs, we'll need to support these features.

features:
* this change allows the user to set the filestore mount path, only creating the remote dir if it's not there.  
* specify a custom image/tag if required

i update this pr as i test it out locally.