### PR TITLE
update rstudio image tag to ee405bcab486

### DIFF
--- a/deployments/rstudio/config/common.yaml
+++ b/deployments/rstudio/config/common.yaml
@@ -55,7 +55,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/rstudio-user-image
-      tag: 41736a10a2cb
+      tag: ee405bcab486
     defaultUrl: "/rstudio"
     extraFiles:
       # DH-216


### PR DESCRIPTION
update rstudio image tag to ee405bcab486

deployments/rstudio/config/common.yaml