### PR TITLE
bump various actions to squelch nodejs 20 warnings

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1
+        uses: irby/get-labels-on-push@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,13 +45,13 @@ jobs:
 
       - name: Check out the image repo
         if: ${{ env.DEPLOY }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: 'gke-gcloud-auth-plugin'
 
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1
+        uses: irby/get-labels-on-push@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -124,13 +124,13 @@ jobs:
 
       - name: Check out the image repo
         if: ${{ env.DEPLOY }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: 'gke-gcloud-auth-plugin'
 

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -47,25 +47,19 @@ jobs:
         if: ${{ env.DEPLOY }}
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 1  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         if: ${{ env.DEPLOY }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-
-      - name: Install Google Cloud SDK
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
@@ -82,6 +76,19 @@ jobs:
           ${{ secrets.SOPS_KEY }}
           EOF
           echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
+
+      - name: Auth to gcloud
+        if: ${{ env.DEPLOY }}
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GKE_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Install Google Cloud SDK
+        if: ${{ env.DEPLOY }}
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Deploy hubs to staging
         if: ${{ env.DEPLOY }}
@@ -126,25 +133,19 @@ jobs:
         if: ${{ env.DEPLOY }}
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 1  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         if: ${{ env.DEPLOY }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-
-      - name: Install Google Cloud SDK
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
@@ -161,6 +162,19 @@ jobs:
           ${{ secrets.SOPS_KEY }}
           EOF
           echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
+
+      - name: Auth to gcloud
+        if: ${{ env.DEPLOY }}
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GKE_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Install Google Cloud SDK
+        if: ${{ env.DEPLOY }}
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Deploy hubs to prod
         if: ${{ env.DEPLOY }}

--- a/.github/workflows/deploy-support.yaml
+++ b/.github/workflows/deploy-support.yaml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1
+        uses: irby/get-labels-on-push@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out the image repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
@@ -35,14 +35,14 @@ jobs:
 
       - name: Auth to gcloud
         if: ${{ env.DEPLOY }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GKE_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: 'gke-gcloud-auth-plugin'
 


### PR DESCRIPTION
our actions were getting the following warnings:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, google-github-actions/setup-gcloud@v2, irby/get-labels-on-push@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

this updates all the offending actions.