### PR TITLE
Revert "bump various actions to squelch nodejs 20 warnings"

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.1.0
+        uses: irby/get-labels-on-push@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,21 +45,27 @@ jobs:
 
       - name: Check out the image repo
         if: ${{ env.DEPLOY }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 1  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install dependencies
         if: ${{ env.DEPLOY }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Install Google Cloud SDK
+        if: ${{ env.DEPLOY }}
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
@@ -77,19 +83,6 @@ jobs:
           EOF
           echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
 
-      - name: Auth to gcloud
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GKE_KEY }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-      - name: Install Google Cloud SDK
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          install_components: 'gke-gcloud-auth-plugin'
-
       - name: Deploy hubs to staging
         if: ${{ env.DEPLOY }}
         run: |
@@ -105,7 +98,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.1.0
+        uses: irby/get-labels-on-push@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -131,21 +124,27 @@ jobs:
 
       - name: Check out the image repo
         if: ${{ env.DEPLOY }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 1  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install dependencies
         if: ${{ env.DEPLOY }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Install Google Cloud SDK
+        if: ${{ env.DEPLOY }}
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
@@ -162,19 +161,6 @@ jobs:
           ${{ secrets.SOPS_KEY }}
           EOF
           echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
-
-      - name: Auth to gcloud
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GKE_KEY }}
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-      - name: Install Google Cloud SDK
-        if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          install_components: 'gke-gcloud-auth-plugin'
 
       - name: Deploy hubs to prod
         if: ${{ env.DEPLOY }}

--- a/.github/workflows/deploy-support.yaml
+++ b/.github/workflows/deploy-support.yaml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.1.0
+        uses: irby/get-labels-on-push@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out the image repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
@@ -35,14 +35,14 @@ jobs:
 
       - name: Auth to gcloud
         if: ${{ env.DEPLOY }}
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GKE_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@v2
         with:
           install_components: 'gke-gcloud-auth-plugin'
 


### PR DESCRIPTION
Reverts cal-icor/cal-icor-hubs#719

the support deploy workflow worked, but apparently the added step to explicitly authenticate to the cluster using `google-github-actions/auth@v3` was unnecessary.  i'll open a new pr w/the associated fixes.