### PR TITLE
fix warnings raised by actionlint

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -31,14 +31,14 @@ jobs:
           # (staging or prod) need to be redeployed.
           #
           if [[ -n ${GITHUB_PR_LABEL_HUB_IMAGES} || -n ${GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT} ]]; then
-            echo "DEPLOY=1" >> $GITHUB_ENV
+            echo "DEPLOY=1" >> "$GITHUB_ENV"
           # Otherwise, check to see if the PR labels contain any hubs, and 
           # deploy just those hubs to staging.
           #
           else
             for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
               if [[ "$label" == hub-* ]]; then
-                echo "DEPLOY=1" >> $GITHUB_ENV
+                echo "DEPLOY=1" >> "$GITHUB_ENV"
               fi
             done
           fi
@@ -64,18 +64,18 @@ jobs:
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
         run: |
-          mkdir -p ${HOME}/bin
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o ${HOME}/bin/sops
-          chmod 755 ${HOME}/bin/sops
-          echo "${HOME}/bin" >> $GITHUB_PATH
+          mkdir -p "${HOME}/bin"
+          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
+          chmod 755 "${HOME}/bin/sops"
+          echo "${HOME}/bin" >> "$GITHUB_PATH"
 
       - name: Store SOPS secret in a file
         if: ${{ env.DEPLOY }}
         run: |
-          cat << EOF > ${HOME}/sops.key
+          cat << EOF > "${HOME}/sops.key"
           ${{ secrets.SOPS_KEY }}
           EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
@@ -86,9 +86,9 @@ jobs:
       - name: Deploy hubs to staging
         if: ${{ env.DEPLOY }}
         run: |
-          while read deployment; do
+          while read -r deployment; do
             echo "Deploying single-user image and hub config to ${deployment}"
-            hubploy --verbose deploy --timeout 30m ${deployment} hub staging
+            hubploy --verbose deploy --timeout 30m "${deployment}" hub staging
             echo
           done < <(python .github/scripts/determine-hub-deployments.py --ignore demo gpu-demo rstudio sage jupyter)
 
@@ -110,14 +110,14 @@ jobs:
           # (staging or prod) need to be redeployed.
           #
           if [[ -n ${GITHUB_PR_LABEL_HUB_IMAGES} || -n ${GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT} ]]; then
-            echo "DEPLOY=1" >> $GITHUB_ENV
+            echo "DEPLOY=1" >> "$GITHUB_ENV"
           # Otherwise, check to see if the PR labels contain any hubs, and 
           # deploy just those hubs to prod.
           #
           else
             for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
               if [[ "$label" == hub-* ]]; then
-                echo "DEPLOY=1" >> $GITHUB_ENV
+                echo "DEPLOY=1" >> "$GITHUB_ENV"
               fi
             done
           fi
@@ -143,18 +143,18 @@ jobs:
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
         run: |
-          mkdir -p ${HOME}/bin
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o ${HOME}/bin/sops
-          chmod 755 ${HOME}/bin/sops
-          echo "${HOME}/bin" >> $GITHUB_PATH
+          mkdir -p "${HOME}/bin"
+          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
+          chmod 755 "${HOME}/bin/sops"
+          echo "${HOME}/bin" >> "$GITHUB_PATH"
 
       - name: Store SOPS secret in a file
         if: ${{ env.DEPLOY }}
         run: |
-          cat << EOF > ${HOME}/sops.key
+          cat << EOF > "${HOME}/sops.key"
           ${{ secrets.SOPS_KEY }}
           EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
@@ -165,8 +165,8 @@ jobs:
       - name: Deploy hubs to prod
         if: ${{ env.DEPLOY }}
         run: |
-          while read deployment; do
+          while read -r deployment; do
             echo "Deploying single-user image and hub config to ${deployment}"
-            hubploy --verbose deploy --timeout 30m ${deployment} hub prod
+            hubploy --verbose deploy --timeout 30m "${deployment}" hub prod
             echo
           done < <(python .github/scripts/determine-hub-deployments.py --ignore demo gpu-demo rstudio sage)

--- a/.github/workflows/deploy-support.yaml
+++ b/.github/workflows/deploy-support.yaml
@@ -29,7 +29,7 @@ jobs:
           for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
             if [[ "$label" == support-deployment ]]; then
               echo "Deploying support charts!"
-              echo "DEPLOY=1" >> $GITHUB_ENV
+              echo "DEPLOY=1" >> "$GITHUB_ENV"
             fi
           done
 
@@ -49,18 +49,18 @@ jobs:
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
         run: |
-          mkdir -p ${HOME}/bin
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o ${HOME}/bin/sops
-          chmod 755 ${HOME}/bin/sops
-          echo "${HOME}/bin" >> $GITHUB_PATH
+          mkdir -p "${HOME}/bin"
+          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
+          chmod 755 "${HOME}/bin/sops"
+          echo "${HOME}/bin" >> "$GITHUB_PATH"
 
       - name: Store SOPS secret in a file
         if: ${{ env.DEPLOY }}
         run: |
-          cat << EOF > ${HOME}/sops.key
+          cat << EOF > "${HOME}/sops.key"
           ${{ secrets.SOPS_KEY }}
           EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
 
       - name: Activate credentials for cluster
         if: ${{ env.DEPLOY }}
@@ -76,8 +76,9 @@ jobs:
       - name: Login to GAR
         if: ${{ env.DEPLOY }}
         run: |
-          cat deployments/jupyter/secrets/gke-key.json | helm registry login \
-            -u _json_key --password-stdin https://us-central1-docker.pkg.dev
+          helm registry login \
+            -u _json_key --password-stdin https://us-central1-docker.pkg.dev \
+            < deployments/jupyter/secrets/gke-key.json
 
       - name: Deploy support helm chart
         if: ${{ env.DEPLOY }}


### PR DESCRIPTION
## Summary

- Quote `$GITHUB_ENV`, `$GITHUB_PATH`, and `${HOME}` paths in shell scripts to prevent globbing/word-splitting (SC2086)
- Add `-r` flag to `while read` loops (SC2162)
- Replace useless `cat file | cmd` with `cmd < file` in `deploy-support.yaml` (SC2002)

Note: `actions/labeler@v4` version warning from actionlint is intentionally left — v5 requires glob pattern migration that is deferred.

## Test plan

- [x] CI action-lint workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)