### PR TITLE
fix ci gke auth: use GKE_KEY SA for GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/.github/workflows/action-lint.yaml
+++ b/.github/workflows/action-lint.yaml
@@ -19,4 +19,4 @@ jobs:
       - name: Lint YAML files
         run: yamllint --no-warnings .
 
-      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d
+      - uses: reviewdog/action-actionlint@v1.72.0

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.1.0
+        uses: irby/get-labels-on-push@v1.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,13 +69,12 @@ jobs:
           chmod 755 "${HOME}/bin/sops"
           echo "${HOME}/bin" >> "$GITHUB_PATH"
 
-      - name: Store SOPS secret in a file
+      - name: Auth to gcloud
         if: ${{ env.DEPLOY }}
-        run: |
-          cat << EOF > "${HOME}/sops.key"
-          ${{ secrets.SOPS_KEY }}
-          EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GKE_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}
@@ -98,7 +97,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.1.0
+        uses: irby/get-labels-on-push@v1.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -148,13 +147,12 @@ jobs:
           chmod 755 "${HOME}/bin/sops"
           echo "${HOME}/bin" >> "$GITHUB_PATH"
 
-      - name: Store SOPS secret in a file
+      - name: Auth to gcloud
         if: ${{ env.DEPLOY }}
-        run: |
-          cat << EOF > "${HOME}/sops.key"
-          ${{ secrets.SOPS_KEY }}
-          EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GKE_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
         if: ${{ env.DEPLOY }}

--- a/.github/workflows/deploy-jupyterhub-home-nfs.yaml
+++ b/.github/workflows/deploy-jupyterhub-home-nfs.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.2.0
+        uses: irby/get-labels-on-push@v1.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -57,14 +57,6 @@ jobs:
           curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
           chmod 755 "${HOME}/bin/sops"
           echo "${HOME}/bin" >> "$GITHUB_PATH"
-
-      - name: Store SOPS secret in a file
-        if: ${{ env.DEPLOY }}
-        run: |
-          cat << EOF > "${HOME}/sops.key"
-          ${{ secrets.SOPS_KEY }}
-          EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
 
       - name: Activate credentials for cluster
         if: ${{ env.DEPLOY }}

--- a/.github/workflows/deploy-support.yaml
+++ b/.github/workflows/deploy-support.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: pr-labels
-        uses: irby/get-labels-on-push@v1.1.0
+        uses: irby/get-labels-on-push@v1.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,14 +53,6 @@ jobs:
           curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
           chmod 755 "${HOME}/bin/sops"
           echo "${HOME}/bin" >> "$GITHUB_PATH"
-
-      - name: Store SOPS secret in a file
-        if: ${{ env.DEPLOY }}
-        run: |
-          cat << EOF > "${HOME}/sops.key"
-          ${{ secrets.SOPS_KEY }}
-          EOF
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/sops.key" >> "$GITHUB_ENV"
 
       - name: Activate credentials for cluster
         if: ${{ env.DEPLOY }}


### PR DESCRIPTION
## Summary

- **Root cause**: `gke-gcloud-auth-plugin` now prioritizes `GOOGLE_APPLICATION_CREDENTIALS` over gcloud's activated user account. Deploy workflows were setting `GOOGLE_APPLICATION_CREDENTIALS` to the SOPS service account key (`sopsaccount@...`), which has no GKE cluster RBAC binding → `system:anonymous` → 403. Broke around May 20 with a gke-gcloud-auth-plugin update on the GitHub Actions runner.
- **Fix**: Granted `hubploy-922` `roles/cloudkms.cryptoKeyDecrypter` on the SOPS KMS key, then switched all deploy workflows to authenticate via `google-github-actions/auth@v3` with `secrets.GKE_KEY` (hubploy-922). This SA now has both KMS decrypt and GKE cluster access, so `GOOGLE_APPLICATION_CREDENTIALS` points to the right account for both SOPS and `gke-gcloud-auth-plugin`.
- **Correctness fixes in other workflows**: bumped `irby/get-labels-on-push` to v1.2.1 across all workflows (Node.js 20 deprecation fix — hard deadline June 2, 2026); replaced `reviewdog/action-actionlint` SHA pin with tagged equivalent `v1.72.0` per repo convention.

## Test plan

- [ ] Merge to staging and verify `deploy-hubs-to-staging` job completes successfully for at least one hub
- [ ] Verify `deploy-support` and `deploy-jupyterhub-home-nfs` workflows still function correctly when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)