### PR TITLE
pin kubernetes client to 35.0.0 to fix hub deploy regression

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ chartpress==2.2.0
 cookiecutter==2.6.0
 git+https://github.com/berkeley-dsep-infra/hubploy.git
 jupyter-repo2docker==2025.12.0
+kubernetes==35.0.0
 myst-parser==4.0.0
 niquests==3.7.2
 pre-commit==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ attrs==23.1.0
 chardet==5.2.0
 chartpress==2.2.0
 git+https://github.com/berkeley-dsep-infra/hubploy.git
+kubernetes==35.0.0
 myst-parser==4.0.0
 niquests==3.7.2
 pre-commit==4.0.1


### PR DESCRIPTION
## Summary

- Pins `kubernetes==35.0.0` in both `requirements.txt` and `dev-requirements.txt`
- `kubernetes 36.0.0` (released 2026-05-20) introduced a breaking change in exec-based credential handling in the Python client
- This caused hubploy's namespace check to authenticate as `system:anonymous` and fail with 403 Forbidden
- Support and jupyterhub-home-nfs deploys (which use Go helm/kubectl) were unaffected; only hubploy's Python kubernetes client was broken

## Test plan

- [ ] Merge to staging and trigger a hub deployment via PR label
- [ ] Verify `deploy-hubs-to-staging` job completes successfully
- [ ] Unpin once the upstream regression is fixed in kubernetes 36.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)