### PR TITLE
comment out unused threshold for the node placeholder scaler

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -193,7 +193,7 @@ node-placeholder-scaler:
   calendarTimezone: "America/Los_Angeles"
   calendarOverrideEnabled: True
 
-  cpuThreshold: 0.25
+  # cpuThreshold: 0.25 # ignore this as our workloads are memory-bound, not cpu
   memoryThreshold: 0.40 # set this pretty high to avoid overloading nodes and get new ones spun up earlier
   scalingStrategy: "mem" # Options: cpu, mem, balanced (default)
   


### PR DESCRIPTION
we don't care about cpu, so even though this value is ignored when calculating when to scale, we should just remove or comment it out.