### PR TITLE
add prometheus concurrent users query script

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,7 @@ niquests==3.7.2
 pre-commit==4.0.1
 pygithub==2.4.0
 pyrsistent==0.19.3
+ruamel.yaml==0.19.1
 ruff==0.7.0
 urllib3==2.7.0
 yamllint==1.35.1

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -119,7 +119,7 @@ def format_text(report):
     T2 = report["threshold2"]
     lines = []
 
-    lines.append("Cal-ICOR JupyterHub Concurrent User Report")
+    lines.append("JupyterHub Concurrent User Report")
     lines.append(f"Generated: {report['generated']}")
     lines.append(
         f"Range: last {days} days  |  Threshold: {T} users per node"
@@ -197,7 +197,7 @@ def format_markdown(report):
     T2 = report["threshold2"]
     lines = []
 
-    lines.append("# Cal-ICOR JupyterHub Concurrent User Report")
+    lines.append("# JupyterHub Concurrent User Report")
     lines.append("")
     lines.append(f"**Generated:** {report['generated']}  ")
     lines.append(
@@ -278,7 +278,7 @@ def format_html(report):
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Cal-ICOR Concurrent Users Report</title>
+  <title>Jupyterhub Concurrent Users Report</title>
   <style>
     body {{ font-family: sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }}
     h1 {{ font-size: 1.4em; }}
@@ -293,7 +293,7 @@ def format_html(report):
   </style>
 </head>
 <body>
-<h1>Cal-ICOR JupyterHub Concurrent User Report</h1>
+<h1>JupyterHub Concurrent User Report</h1>
 <p class="meta">
   Generated: {report["generated"]} &nbsp;|&nbsp;
   Range: last {days} days &nbsp;|&nbsp;

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -13,8 +13,17 @@ Then run:
     python3 scripts/query_concurrent_users.py
 
 Optional arguments:
-    --days                Number of days to look back (default: 90)
-    --step                Query resolution step for instant queries (default: 5m)
+    --days                Number of days to look back (default: 90). Mutually exclusive
+                          with --start/--end.
+    --start               Start of the query window in local time, e.g. "2026-03-01" or
+                          "2026-03-01 08:00". Requires --end. Mutually exclusive with --days.
+    --end                 End of the query window in local time, e.g. "2026-04-15" or
+                          "2026-04-15 18:00". Requires --start. Mutually exclusive with --days.
+    --step                Sub-query resolution for instant queries (peak, % above threshold).
+                          In Prometheus subquery notation [90d:5m], this is the '5m': how
+                          finely Prometheus resamples the inner expression across the lookback
+                          window. Does not affect the time-series data returned for the
+                          hourly/daily/weekly breakdown tables. (default: 5m)
     --url                 Prometheus URL (default: http://localhost:9090)
     --threshold           User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
     --timezone            IANA timezone for local time display, should match hub users' location
@@ -24,6 +33,44 @@ Optional arguments:
     --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
                           explicit CLI args always win.
     --debug               Print each Prometheus query and sample counts as the script runs.
+
+Two independent resolutions are used per run:
+
+  1. Instant query sub-query resolution (--step, default 5m)
+     Controls how finely the peak/threshold instant queries sample across the lookback
+     window. Returns a single aggregated value, not a time series.
+
+  2. Range data sample interval (not user-configurable)
+     Controls how many data points are fetched for the hourly, daily, and week-by-week
+     breakdown tables. Auto-scales with the query window to maximise detail while staying
+     within Prometheus point limits (~11k points):
+         ≤  7 days  →  5-minute sample interval  (~2,000 points) — single-week deep-dives
+         ≤ 30 days  → 15-minute sample interval  (~2,900 points) — month-long snapshots
+         ≤ 90 days  → 30-minute sample interval  (~4,300 points) — default rolling view
+         > 90 days  → 60-minute sample interval  (~4,300 points) — semester-plus ranges
+
+Note: --start/--end ranges shorter than 7 days suppress the Active (WAU) column in
+the week-by-week table. jupyterhub_active_users always reflects a rolling 7-day window,
+so its values would extend outside the query range and be misleading for short spans.
+
+Examples:
+    # Default: last 90 days, 30-minute sample interval for breakdown tables
+    python3 scripts/query_concurrent_users.py
+
+    # Last 30 days, 15-minute sample interval
+    python3 scripts/query_concurrent_users.py -d 30
+
+    # Full spring semester — 115-day span, 60-minute sample interval
+    python3 scripts/query_concurrent_users.py \\
+        --start "2026-01-20" --end "2026-05-15" -r html
+
+    # Historical month snapshot — 30-day span, 15-minute sample interval
+    python3 scripts/query_concurrent_users.py \\
+        --start "2026-02-01" --end "2026-03-01"
+
+    # Midterm week deep-dive — 5-day span, 5-minute sample interval for maximum granularity
+    python3 scripts/query_concurrent_users.py \\
+        --start "2026-03-09 00:00" --end "2026-03-13 23:59"
 
 Example config file (my-deployment.yaml):
     namespace_pattern: ".*-staging"
@@ -35,7 +82,6 @@ import argparse
 import calendar
 import json
 import sys
-import time
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -49,11 +95,25 @@ from ruamel.yaml import YAML
 DAYS_OF_WEEK = list(calendar.day_abbr)
 
 
-def query(url, promql):
+def parse_local_dt(s, tz):
+    """Parse a date/datetime string in the given timezone."""
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=tz)
+        except ValueError:
+            pass
+    raise argparse.ArgumentTypeError(
+        f"Cannot parse datetime {s!r}; use YYYY-MM-DD or YYYY-MM-DD HH:MM"
+    )
+
+
+def prom_query(url, promql, time=None):
     """Run an instant Prometheus query and return parsed JSON."""
-    params = urlencode({"query": promql})
+    params = {"query": promql}
+    if time is not None:
+        params["time"] = time
     try:
-        with urlopen(f"{url}/api/v1/query?{params}") as resp:
+        with urlopen(f"{url}/api/v1/query?{urlencode(params)}") as resp:
             return json.load(resp)
     except URLError as e:
         print(f"Error connecting to Prometheus at {url}: {e}")
@@ -85,23 +145,19 @@ def query_range(url, promql, start, end, step):
     return data["data"]["result"][0]["values"]
 
 
-def get_range_samples(url, days, tz_name, namespace_pattern):
+def get_range_samples(
+    url, start_ts, end_ts, tz_name, namespace_pattern, step=1800, debug=False
+):
     """
-    Fetch total running servers at 30m resolution over the given number of days.
+    Fetch total running servers over [start_ts, end_ts] at the given step (seconds).
     Returns a list of (datetime_local, value) tuples, converted to tz_name.
     """
-    end = int(time.time())
-    start = end - days * 86400
     tz = ZoneInfo(tz_name)
+    promql = f'sum(jupyterhub_running_servers{{namespace=~"{namespace_pattern}"}})'
+    if debug:
+        print(f"  [debug]   {promql}")
 
-    # 90 days at 30m = ~4320 samples, well within the 11000-point limit
-    values = query_range(
-        url,
-        f'sum(jupyterhub_running_servers{{namespace=~"{namespace_pattern}"}})',
-        start,
-        end,
-        step=1800,
-    )
+    values = query_range(url, promql, start_ts, end_ts, step=step)
 
     samples = []
     for ts, val in values:
@@ -119,15 +175,15 @@ def section(title):
 
 def format_text(report):
     """Render report data as plain text (mirrors stdout output)."""
-    days = report["days"]
     T = report["threshold"]
     T2 = report["threshold2"]
+    rl = report["range_label"]
     lines = []
 
     lines.append("JupyterHub Concurrent User Report")
     lines.append(f"Generated: {report['generated']}")
     lines.append(
-        f"Range: last {days} days  |  Thresholds: {T}, {T2} users per node"
+        f"Range: {rl}  |  Thresholds: {T}, {T2} users per node"
         f"  |  Namespace: {report['namespace_pattern']}  |  Timezone: {report['timezone']}"
     )
     lines.append(
@@ -142,7 +198,7 @@ def format_text(report):
     )
 
     lines.append(f"\n{'=' * 60}")
-    lines.append(f"  Overall statistics (last {days} days)")
+    lines.append(f"  Overall statistics ({rl})")
     lines.append(f"{'=' * 60}")
     lines.append(f"  Peak concurrent users (all hubs): {report['overall']['peak']}")
     for a in report["overall"]["above"]:
@@ -152,7 +208,7 @@ def format_text(report):
         )
 
     lines.append(f"\n{'=' * 60}")
-    lines.append(f"  Per-namespace peak concurrent users (last {days} days)")
+    lines.append(f"  Per-namespace peak concurrent users ({rl})")
     lines.append(f"{'=' * 60}")
     lines.append(f"  {'Namespace':<28} {'Peak':>5}  Chart")
     lines.append(f"  {'-' * 28} {'-' * 5}  -----")
@@ -173,9 +229,11 @@ def format_text(report):
     for w in report["weeks"]:
         bar = "#" * (w["peak"] // 5)
         lines.append(
-            f"  {w['week']:<12} {w['peak']:>5}  {w['active']:>6}  "
+            f"  {w['week']:<12} {w['peak']:>5}  {str(w['active']):>6}  "
             f"{w['hrs_t']:>6.1f}h  {w['hrs_t2']:>7.1f}h  {bar}"
         )
+    if report.get("active_note"):
+        lines.append(f"  * {report['active_note']}")
 
     pct_col = f"Pct>{T}"
     lines.append(f"\n{'=' * 60}")
@@ -208,16 +266,16 @@ def format_text(report):
 
 def format_markdown(report):
     """Render report data as Markdown."""
-    days = report["days"]
     T = report["threshold"]
     T2 = report["threshold2"]
+    rl = report["range_label"]
     lines = []
 
     lines.append("# JupyterHub Concurrent User Report")
     lines.append("")
     lines.append(f"**Generated:** {report['generated']}  ")
     lines.append(
-        f"**Range:** last {days} days  |  "
+        f"**Range:** {rl}  |  "
         f"**Thresholds:** {T}, {T2} users per node  |  "
         f"**Namespace:** {report['namespace_pattern']}  |  "
         f"**Timezone:** {report['timezone']}"
@@ -242,7 +300,7 @@ def format_markdown(report):
     lines.append("| Chart | Bar chart; each # = 5 users |")
     lines.append("")
 
-    lines.append(f"## Overall statistics (last {days} days)")
+    lines.append(f"## Overall statistics ({rl})")
     lines.append("")
     lines.append("| Metric | Value |")
     lines.append("|---|---|")
@@ -254,7 +312,7 @@ def format_markdown(report):
         )
     lines.append("")
 
-    lines.append(f"## Per-namespace peak concurrent users (last {days} days)")
+    lines.append(f"## Per-namespace peak concurrent users ({rl})")
     lines.append("")
     lines.append("| Namespace | Peak |")
     lines.append("|---|---|")
@@ -271,6 +329,8 @@ def format_markdown(report):
             f"| {w['week']} | {w['peak']} | {w['active']}"
             f" | {w['hrs_t']:.1f}h | {w['hrs_t2']:.1f}h |"
         )
+    if report.get("active_note"):
+        lines.append(f"\n*{report['active_note']}*")
     lines.append("")
 
     lines.append("## Concurrent users by hour of day (local time)")
@@ -297,9 +357,9 @@ def format_markdown(report):
 
 def format_html(report):
     """Render report data as a self-contained HTML document."""
-    days = report["days"]
     T = report["threshold"]
     T2 = report["threshold2"]
+    rl = report["range_label"]
 
     def th(*cells):
         return "<tr>" + "".join(f"<th>{c}</th>" for c in cells) + "</tr>"
@@ -331,7 +391,7 @@ def format_html(report):
 <h1>JupyterHub Concurrent User Report</h1>
 <p class="meta">
   Generated: {report["generated"]} &nbsp;|&nbsp;
-  Range: last {days} days &nbsp;|&nbsp;
+  Range: {rl} &nbsp;|&nbsp;
   Thresholds: {T}, {T2} users per node &nbsp;|&nbsp;
   Namespace: {report["namespace_pattern"]} &nbsp;|&nbsp;
   Timezone: {report["timezone"]}
@@ -351,7 +411,7 @@ def format_html(report):
         f"</table>"
     )
 
-    parts.append(f"<h2>Overall statistics (last {days} days)</h2><table>")
+    parts.append(f"<h2>Overall statistics ({rl})</h2><table>")
     parts.append(th("Metric", "Value"))
     parts.append(
         td("Peak concurrent users", f"<strong>{report['overall']['peak']}</strong>")
@@ -365,9 +425,7 @@ def format_html(report):
         )
     parts.append("</table>")
 
-    parts.append(
-        f"<h2>Per-namespace peak concurrent users (last {days} days)</h2><table>"
-    )
+    parts.append(f"<h2>Per-namespace peak concurrent users ({rl})</h2><table>")
     parts.append(th("Namespace", "Peak", "Chart"))
     for hub, val in report["hubs"]:
         bar = "#" * (val // 5)
@@ -387,6 +445,8 @@ def format_html(report):
             )
         )
     parts.append("</table>")
+    if report.get("active_note"):
+        parts.append(f"<p><em>{report['active_note']}</em></p>")
 
     parts.append("<h2>Concurrent users by hour of day (local time)</h2><table>")
     parts.append(th("Hour", "Peak", "Avg", f"% &gt; {T}"))
@@ -408,9 +468,15 @@ def format_html(report):
 
 def write_report(report, fmt, script_dir):
     """Write a formatted report to scripts/reports/."""
-    date_str = datetime.now().strftime("%Y-%m-%d")
     ext = {"text": "txt", "markdown": "md", "md": "md", "html": "html"}[fmt]
-    path = script_dir / "reports" / f"concurrent-users-{date_str}.{ext}"
+    if report.get("start") and report.get("end"):
+        start_slug = report["start"].replace(" ", "T").replace(":", "")
+        end_slug = report["end"].replace(" ", "T").replace(":", "")
+        filename = f"concurrent-users-{start_slug}-to-{end_slug}.{ext}"
+    else:
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        filename = f"concurrent-users-{date_str}.{ext}"
+    path = script_dir / "reports" / filename
 
     formatters = {
         "text": format_text,
@@ -423,13 +489,60 @@ def write_report(report, fmt, script_dir):
 
 
 def main(args):
-    window = f"{args.days}d"
-    subquery = f"[{window}:{args.step}]"
     ns_filter = f'namespace=~"{args.namespace_pattern}"'
     T = args.threshold
     T2 = int(T * 1.5)
+    tz = ZoneInfo(args.timezone)
 
-    print(f"Querying {args.url} over the last {args.days} days")
+    # Determine query window from either --start/--end or --days
+    if args.start:
+        start_dt = parse_local_dt(args.start, tz)
+        end_dt = parse_local_dt(args.end, tz)
+        if end_dt <= start_dt:
+            parser.error("--end must be after --start.")
+        range_label = f"from {args.start} to {args.end}"
+        query_time = int(end_dt.timestamp())
+    else:
+        end_dt = datetime.now(tz)
+        start_dt = end_dt - timedelta(days=args.days)
+        range_label = f"last {args.days} days"
+        query_time = None
+
+    duration = end_dt - start_dt
+    start_ts = int(start_dt.timestamp())
+    end_ts = int(end_dt.timestamp())
+    window = f"{int(duration.total_seconds())}s"
+
+    # Auto-scale range-query step to maximise detail within Prometheus point limits
+    if duration <= timedelta(days=7):
+        range_step = 300  # 5m  — deep-dive granularity
+    elif duration <= timedelta(days=30):
+        range_step = 900  # 15m — month snapshot
+    elif duration <= timedelta(days=90):
+        range_step = 1800  # 30m — default rolling view
+    else:
+        range_step = 3600  # 60m — semester-plus spans
+
+    step_label = {300: "5m", 900: "15m", 1800: "30m", 3600: "60m"}.get(
+        range_step, f"{range_step}s"
+    )
+
+    # WAU metric reflects a rolling 7-day window; suppress for shorter ranges
+    show_active = duration >= timedelta(days=7)
+
+    subquery = f"[{window}:{args.step}]"
+
+    if args.debug:
+        print("[debug] time window:")
+        print(f"  start:      {start_dt.strftime('%Y-%m-%d %H:%M %Z')}")
+        print(f"  end:        {end_dt.strftime('%Y-%m-%d %H:%M %Z')}")
+        print(f"  duration:   {duration}")
+        print(f"  range_step: {step_label}")
+        print(f"  subquery:   {subquery}")
+        if query_time is not None:
+            print(f"  query_time: {query_time}")
+
+    print(f"Querying {args.url} — {range_label}")
     print(
         f"Thresholds: {T}, {T2} users per node  |  "
         f"Namespace: {args.namespace_pattern}  |  Timezone: {args.timezone}"
@@ -446,14 +559,23 @@ def main(args):
     )
 
     report = {
-        "generated": datetime.now(ZoneInfo(args.timezone)).strftime(
-            "%Y-%m-%d %H:%M %Z"
-        ),
-        "days": args.days,
+        "generated": datetime.now(tz).strftime("%Y-%m-%d %H:%M %Z"),
+        "range_label": range_label,
+        "start": args.start,
+        "end": args.end,
         "threshold": T,
         "threshold2": T2,
         "timezone": args.timezone,
         "namespace_pattern": args.namespace_pattern,
+        "active_note": (
+            None
+            if show_active
+            else (
+                "Active column suppressed: query range is shorter than 7 days. "
+                "jupyterhub_active_users always reflects a rolling 7-day window "
+                "and would extend outside the requested range."
+            )
+        ),
         "overall": {"peak": None, "above": []},
         "hubs": [],
         "weeks": [],
@@ -464,28 +586,28 @@ def main(args):
     # -------------------------------------------------------------------------
     # Section 1: Overall peak + time-above-threshold
     # -------------------------------------------------------------------------
-    section(f"Overall statistics (last {args.days} days)")
+    section(f"Overall statistics ({range_label})")
 
+    promql = f"max_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})"
     if args.debug:
         print("  [debug] querying overall peak concurrent users")
-    data = query(
-        args.url,
-        f"max_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
-    )
+        print(f"  [debug]   {promql}")
+    data = prom_query(args.url, promql, time=query_time)
     peak = int(data["data"]["result"][0]["value"][1])
     print(f"  Peak concurrent users (all hubs): {peak}")
     report["overall"]["peak"] = peak
 
     for n in [T, T2]:
+        promql = (
+            f"sum_over_time((sum(jupyterhub_running_servers{{{ns_filter}}}) > bool {n}){subquery})"
+            f" / count_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})"
+        )
         if args.debug:
             print(f"  [debug] querying % of time above {n} users")
-        data = query(
-            args.url,
-            f"sum_over_time((sum(jupyterhub_running_servers{{{ns_filter}}}) > bool {n}){subquery})"
-            f" / count_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
-        )
+            print(f"  [debug]   {promql}")
+        data = prom_query(args.url, promql, time=query_time)
         frac = float(data["data"]["result"][0]["value"][1])
-        hours_above = frac * args.days * 24
+        hours_above = frac * duration.total_seconds() / 3600
         print(
             f"  % of time above {n:>3} users per node: "
             f"{frac * 100:5.2f}%  (~{hours_above:.1f} hours total)"
@@ -497,13 +619,13 @@ def main(args):
     # -------------------------------------------------------------------------
     # Section 2: Per-hub peak
     # -------------------------------------------------------------------------
-    section(f"Per-namespace peak concurrent users (last {args.days} days)")
+    section(f"Per-namespace peak concurrent users ({range_label})")
 
+    promql = f"max_over_time(jupyterhub_running_servers{{{ns_filter}}}{subquery})"
     if args.debug:
         print("  [debug] querying per-namespace peak concurrent users")
-    data = query(
-        args.url, f"max_over_time(jupyterhub_running_servers{{{ns_filter}}}{subquery})"
-    )
+        print(f"  [debug]   {promql}")
+    data = prom_query(args.url, promql, time=query_time)
     hubs = {}
     for r in data["data"]["result"]:
         ns = r["metric"].get("namespace", "unknown")
@@ -524,9 +646,17 @@ def main(args):
     # Fetch range data once for the remaining analyses (30m resolution)
     # -------------------------------------------------------------------------
     if args.debug:
-        print(f"\n  [debug] fetching {args.days}d of range samples at 30m resolution")
+        print(
+            f"\n  [debug] fetching range samples at {step_label} resolution ({range_label})"
+        )
     samples = get_range_samples(
-        args.url, args.days, args.timezone, args.namespace_pattern
+        args.url,
+        start_ts,
+        end_ts,
+        args.timezone,
+        args.namespace_pattern,
+        step=range_step,
+        debug=args.debug,
     )
     if args.debug:
         print(f"  [debug] got {len(samples)} samples")
@@ -536,28 +666,25 @@ def main(args):
     # -------------------------------------------------------------------------
     section("Week-by-week breakdown (Mon–Sun, local time)")
 
-    # Fetch weekly active users: last sample per week gives WAU for that week
-    if args.debug:
-        print(
-            "  [debug] fetching weekly active users (jupyterhub_active_users{period='7d'})"
-        )
-    _end_ts = int(time.time())
-    _start_ts = _end_ts - args.days * 86400
-    _tz = ZoneInfo(args.timezone)
-    _au_vals = query_range(
-        args.url,
-        f'sum(max(jupyterhub_active_users{{period="7d", {ns_filter}}}) by (namespace))',
-        _start_ts,
-        _end_ts,
-        step=1800,
-    )
+    # Fetch weekly active users: last sample per week gives WAU for that week.
+    # Suppressed for ranges < 7 days since the metric always reflects a 7-day window.
     week_active_users = {}
-    for _ts, _val in _au_vals:
-        _dt = datetime.fromtimestamp(int(_ts), tz=_tz)
-        _wk = (_dt - timedelta(days=_dt.weekday())).strftime("%Y-%m-%d")
-        week_active_users[_wk] = int(float(_val))
-    if args.debug:
-        print(f"  [debug] got WAU data for {len(week_active_users)} weeks")
+    if show_active:
+        wau_promql = f'sum(max(jupyterhub_active_users{{period="7d", {ns_filter}}}) by (namespace))'
+        if args.debug:
+            print(
+                "  [debug] fetching weekly active users (jupyterhub_active_users{period='7d'})"
+            )
+            print(f"  [debug]   {wau_promql}")
+        _au_vals = query_range(args.url, wau_promql, start_ts, end_ts, step=1800)
+        for _ts, _val in _au_vals:
+            _dt = datetime.fromtimestamp(int(_ts), tz=tz)
+            _wk = (_dt - timedelta(days=_dt.weekday())).strftime("%Y-%m-%d")
+            week_active_users[_wk] = int(float(_val))
+        if args.debug:
+            print(f"  [debug] got WAU data for {len(week_active_users)} weeks")
+    elif args.debug:
+        print("  [debug] skipping WAU query: range shorter than 7 days")
 
     week_samples = defaultdict(list)
     for dt, v in samples:
@@ -571,16 +698,16 @@ def main(args):
         f"{hrs_t_col:>7}  {hrs_t2_col:>8}  Chart"
     )
     print(f"  {'-' * 12} {'-' * 5}  {'-' * 6}  {'-' * 7}  {'-' * 8}  -----")
+    sample_hours = range_step / 3600
     for week in sorted(week_samples):
         s = week_samples[week]
         wpeak = max(s)
-        active = week_active_users.get(week, 0)
-        # each sample = 30 min
-        hrs_t = sum(1 for v in s if v > T) * 0.5
-        hrs_t2 = sum(1 for v in s if v > T2) * 0.5
+        active = week_active_users.get(week, "--") if show_active else "--"
+        hrs_t = sum(1 for v in s if v > T) * sample_hours
+        hrs_t2 = sum(1 for v in s if v > T2) * sample_hours
         bar = "#" * (wpeak // 5)
         print(
-            f"  {week:<12} {wpeak:>5}  {active:>6}  "
+            f"  {week:<12} {wpeak:>5}  {str(active):>6}  "
             f"{hrs_t:>6.1f}h  {hrs_t2:>7.1f}h  {bar}"
         )
         report["weeks"].append(
@@ -592,6 +719,8 @@ def main(args):
                 "hrs_t2": hrs_t2,
             }
         )
+    if report.get("active_note"):
+        print(f"  * {report['active_note']}")
 
     # -------------------------------------------------------------------------
     # Section 4: Hour-of-day breakdown
@@ -668,7 +797,23 @@ if __name__ == "__main__":
         "-c", "--config", metavar="FILE", help="Path to a YAML config file"
     )
     parser.add_argument(
-        "-d", "--days", type=int, default=90, help="Days to look back (default: 90)"
+        "-d",
+        "--days",
+        type=int,
+        default=None,
+        help="Days to look back (default: 90). Mutually exclusive with --start/--end.",
+    )
+    parser.add_argument(
+        "--start",
+        metavar="DATETIME",
+        help='Start of query window in local timezone, e.g. "2026-03-01" or "2026-03-01 08:00". '
+        "Requires --end. Mutually exclusive with --days.",
+    )
+    parser.add_argument(
+        "--end",
+        metavar="DATETIME",
+        help='End of query window in local timezone, e.g. "2026-04-15" or "2026-04-15 18:00". '
+        "Requires --start. Mutually exclusive with --days.",
     )
     parser.add_argument(
         "--step",
@@ -716,5 +861,19 @@ if __name__ == "__main__":
         parser.set_defaults(**config_defaults)
 
     args = parser.parse_args()
+
+    using_range = bool(args.start or args.end)
+    using_days = args.days is not None
+    if using_range and using_days:
+        parser.error("--start/--end and --days are mutually exclusive.")
+    if bool(args.start) != bool(args.end):
+        parser.error("--start and --end must both be provided together.")
+    if not using_days and not using_range:
+        args.days = 90
+
+    if args.debug:
+        print("[debug] resolved args:")
+        for k, v in sorted(vars(args).items()):
+            print(f"  {k}: {v!r}")
 
     main(args)

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -9,7 +9,7 @@ Then run:
     python3 scripts/query_concurrent_users.py
 
 Optional arguments:
-    --days           Number of days to look back (default: 148)
+    --days           Number of days to look back (default: 90)
     --step           Query resolution step for instant queries (default: 5m)
     --url            Prometheus URL (default: http://localhost:9090)
     --threshold      User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
@@ -24,7 +24,7 @@ import json
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlencode
@@ -372,7 +372,9 @@ def main(args):
     print(f"Threshold: {T} users  |  Timezone: {args.timezone}\n")
 
     report = {
-        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        "generated": datetime.now(ZoneInfo(args.timezone)).strftime(
+            "%Y-%m-%d %H:%M %Z"
+        ),
         "days": args.days,
         "threshold": T,
         "threshold2": T2,
@@ -532,7 +534,7 @@ if __name__ == "__main__":
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "-d", "--days", type=int, default=148, help="Days to look back (default: 148)"
+        "-d", "--days", type=int, default=90, help="Days to look back (default: 90)"
     )
     parser.add_argument(
         "--step",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -12,7 +12,7 @@ Optional arguments:
     --days      Number of days to look back (default: 148)
     --step      Query resolution step for instant queries (default: 5m)
     --url       Prometheus URL (default: http://localhost:9090)
-    --threshold User count threshold for "above N users" stats (default: 80)
+    --threshold User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
     --tz-offset Hours offset from UTC for local time display (default: -7 for PDT)
 """
 
@@ -119,7 +119,7 @@ def main():
         "--threshold",
         type=int,
         default=80,
-        help="User count threshold for percentage/hours stats (default: 80)",
+        help="User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.",
     )
     parser.add_argument(
         "--tz-offset",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -122,7 +122,7 @@ def format_text(report):
     lines.append("Cal-ICOR JupyterHub Concurrent User Report")
     lines.append(f"Generated: {report['generated']}")
     lines.append(
-        f"Range: last {days} days  |  Threshold: {T} users"
+        f"Range: last {days} days  |  Threshold: {T} users per node"
         f"  |  Timezone: {report['timezone']}"
     )
 
@@ -202,7 +202,7 @@ def format_markdown(report):
     lines.append(f"**Generated:** {report['generated']}  ")
     lines.append(
         f"**Range:** last {days} days  |  "
-        f"**Threshold:** {T} users  |  "
+        f"**Threshold:** {T} users per node  |  "
         f"**Timezone:** {report['timezone']}"
     )
     lines.append("")
@@ -297,7 +297,7 @@ def format_html(report):
 <p class="meta">
   Generated: {report["generated"]} &nbsp;|&nbsp;
   Range: last {days} days &nbsp;|&nbsp;
-  Threshold: {T} users &nbsp;|&nbsp;
+  Threshold: {T} users per node &nbsp;|&nbsp;
   Timezone: {report["timezone"]}
 </p>"""
     )
@@ -379,7 +379,7 @@ def main(args):
     T2 = T + 40
 
     print(f"Querying {args.url} over the last {args.days} days")
-    print(f"Threshold: {T} users  |  Timezone: {args.timezone}\n")
+    print(f"Threshold: {T} users per node  |  Timezone: {args.timezone}\n")
 
     report = {
         "generated": datetime.now(ZoneInfo(args.timezone)).strftime(

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -122,8 +122,8 @@ def format_text(report):
     lines.append("JupyterHub Concurrent User Report")
     lines.append(f"Generated: {report['generated']}")
     lines.append(
-        f"Range: last {days} days  |  Threshold: {T} users per node"
-        f"  |  Timezone: {report['timezone']}"
+        f"Range: last {days} days  |  Thresholds: {T}, {T2} users per node"
+        f"  |  Namespace: {report['namespace_pattern']}  |  Timezone: {report['timezone']}"
     )
 
     lines.append(f"\n{'=' * 60}")
@@ -132,14 +132,14 @@ def format_text(report):
     lines.append(f"  Peak concurrent users (all hubs): {report['overall']['peak']}")
     for a in report["overall"]["above"]:
         lines.append(
-            f"  Fraction of time above {a['n']:>3} users: "
+            f"  % of time above {a['n']:>3} users per node: "
             f"{a['pct']:5.2f}%  (~{a['hours']:.1f} hours total)"
         )
 
     lines.append(f"\n{'=' * 60}")
-    lines.append(f"  Per-hub peak concurrent users (last {days} days)")
+    lines.append(f"  Per-namespace peak concurrent users (last {days} days)")
     lines.append(f"{'=' * 60}")
-    lines.append(f"  {'Hub':<28} {'Peak':>5}  Chart")
+    lines.append(f"  {'Namespace':<28} {'Peak':>5}  Chart")
     lines.append(f"  {'-' * 28} {'-' * 5}  -----")
     for hub, val in report["hubs"]:
         bar = "#" * (val // 5)
@@ -151,14 +151,14 @@ def format_text(report):
     lines.append("  Week-by-week breakdown (Mon-Sun, local time)")
     lines.append(f"{'=' * 60}")
     lines.append(
-        f"  {'Week of':<12} {'Peak':>5}  {'Avg':>5}  "
+        f"  {'Week of':<12} {'Peak':>5}  {'Active':>6}  "
         f"{hrs_t_col:>7}  {hrs_t2_col:>8}  Chart"
     )
-    lines.append(f"  {'-' * 12} {'-' * 5}  {'-' * 5}  {'-' * 7}  {'-' * 8}  -----")
+    lines.append(f"  {'-' * 12} {'-' * 5}  {'-' * 6}  {'-' * 7}  {'-' * 8}  -----")
     for w in report["weeks"]:
         bar = "#" * (w["peak"] // 5)
         lines.append(
-            f"  {w['week']:<12} {w['peak']:>5}  {w['avg']:>5.1f}  "
+            f"  {w['week']:<12} {w['peak']:>5}  {w['active']:>6}  "
             f"{w['hrs_t']:>6.1f}h  {w['hrs_t2']:>7.1f}h  {bar}"
         )
 
@@ -202,7 +202,8 @@ def format_markdown(report):
     lines.append(f"**Generated:** {report['generated']}  ")
     lines.append(
         f"**Range:** last {days} days  |  "
-        f"**Threshold:** {T} users per node  |  "
+        f"**Thresholds:** {T}, {T2} users per node  |  "
+        f"**Namespace:** {report['namespace_pattern']}  |  "
         f"**Timezone:** {report['timezone']}"
     )
     lines.append("")
@@ -214,14 +215,14 @@ def format_markdown(report):
     lines.append(f"| Peak concurrent users | **{report['overall']['peak']}** |")
     for a in report["overall"]["above"]:
         lines.append(
-            f"| Fraction of time above {a['n']} users"
+            f"| % of time above {a['n']} users per node"
             f" | {a['pct']:.2f}% (~{a['hours']:.1f} hours) |"
         )
     lines.append("")
 
-    lines.append(f"## Per-hub peak concurrent users (last {days} days)")
+    lines.append(f"## Per-namespace peak concurrent users (last {days} days)")
     lines.append("")
-    lines.append("| Hub | Peak |")
+    lines.append("| Namespace | Peak |")
     lines.append("|---|---|")
     for hub, val in report["hubs"]:
         lines.append(f"| {hub} | {val} |")
@@ -229,11 +230,11 @@ def format_markdown(report):
 
     lines.append("## Week-by-week breakdown (Mon-Sun, local time)")
     lines.append("")
-    lines.append(f"| Week of | Peak | Avg | Hrs > {T} | Hrs > {T2} |")
+    lines.append(f"| Week of | Peak | Active | Hrs > {T} | Hrs > {T2} |")
     lines.append("|---|---|---|---|---|")
     for w in report["weeks"]:
         lines.append(
-            f"| {w['week']} | {w['peak']} | {w['avg']:.1f}"
+            f"| {w['week']} | {w['peak']} | {w['active']}"
             f" | {w['hrs_t']:.1f}h | {w['hrs_t2']:.1f}h |"
         )
     lines.append("")
@@ -278,7 +279,7 @@ def format_html(report):
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Jupyterhub Concurrent Users Report</title>
+  <title>JupyterHub Concurrent User Report</title>
   <style>
     body {{ font-family: sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }}
     h1 {{ font-size: 1.4em; }}
@@ -297,7 +298,8 @@ def format_html(report):
 <p class="meta">
   Generated: {report["generated"]} &nbsp;|&nbsp;
   Range: last {days} days &nbsp;|&nbsp;
-  Threshold: {T} users per node &nbsp;|&nbsp;
+  Thresholds: {T}, {T2} users per node &nbsp;|&nbsp;
+  Namespace: {report["namespace_pattern"]} &nbsp;|&nbsp;
   Timezone: {report["timezone"]}
 </p>"""
     )
@@ -310,27 +312,29 @@ def format_html(report):
     for a in report["overall"]["above"]:
         parts.append(
             td(
-                f"Fraction of time above {a['n']} users",
+                f"% of time above {a['n']} users per node",
                 f"{a['pct']:.2f}% (~{a['hours']:.1f} hours)",
             )
         )
     parts.append("</table>")
 
-    parts.append(f"<h2>Per-hub peak concurrent users (last {days} days)</h2><table>")
-    parts.append(th("Hub", "Peak", "Chart"))
+    parts.append(
+        f"<h2>Per-namespace peak concurrent users (last {days} days)</h2><table>"
+    )
+    parts.append(th("Namespace", "Peak", "Chart"))
     for hub, val in report["hubs"]:
         bar = "#" * (val // 5)
         parts.append(td(hub, val, f'<span class="bar">{bar}</span>'))
     parts.append("</table>")
 
     parts.append("<h2>Week-by-week breakdown (Mon-Sun, local time)</h2><table>")
-    parts.append(th("Week of", "Peak", "Avg", f"Hrs &gt; {T}", f"Hrs &gt; {T2}"))
+    parts.append(th("Week of", "Peak", "Active", f"Hrs &gt; {T}", f"Hrs &gt; {T2}"))
     for w in report["weeks"]:
         parts.append(
             td(
                 w["week"],
                 w["peak"],
-                f"{w['avg']:.1f}",
+                w["active"],
                 f"{w['hrs_t']:.1f}h",
                 f"{w['hrs_t2']:.1f}h",
             )
@@ -379,7 +383,10 @@ def main(args):
     T2 = T + 40
 
     print(f"Querying {args.url} over the last {args.days} days")
-    print(f"Threshold: {T} users per node  |  Timezone: {args.timezone}\n")
+    print(
+        f"Thresholds: {T}, {T2} users per node  |  "
+        f"Namespace: {args.namespace_pattern}  |  Timezone: {args.timezone}\n"
+    )
 
     report = {
         "generated": datetime.now(ZoneInfo(args.timezone)).strftime(
@@ -389,6 +396,7 @@ def main(args):
         "threshold": T,
         "threshold2": T2,
         "timezone": args.timezone,
+        "namespace_pattern": args.namespace_pattern,
         "overall": {"peak": None, "above": []},
         "hubs": [],
         "weeks": [],
@@ -418,7 +426,7 @@ def main(args):
         frac = float(data["data"]["result"][0]["value"][1])
         hours_above = frac * args.days * 24
         print(
-            f"  Fraction of time above {n:>3} users: "
+            f"  % of time above {n:>3} users per node: "
             f"{frac * 100:5.2f}%  (~{hours_above:.1f} hours total)"
         )
         report["overall"]["above"].append(
@@ -428,7 +436,7 @@ def main(args):
     # -------------------------------------------------------------------------
     # Section 2: Per-hub peak
     # -------------------------------------------------------------------------
-    section(f"Per-hub peak concurrent users (last {args.days} days)")
+    section(f"Per-namespace peak concurrent users (last {args.days} days)")
 
     data = query(
         args.url, f"max_over_time(jupyterhub_running_servers{{{ns_filter}}}{subquery})"
@@ -440,7 +448,7 @@ def main(args):
         if val > hubs.get(ns, 0):
             hubs[ns] = val
 
-    print(f"  {'Hub':<28} {'Peak':>5}  Chart")
+    print(f"  {'Namespace':<28} {'Peak':>5}  Chart")
     print(f"  {'-' * 28} {'-' * 5}  -----")
     for hub, val in sorted(hubs.items(), key=lambda x: -x[1]):
         if val == 0:
@@ -461,30 +469,55 @@ def main(args):
     # -------------------------------------------------------------------------
     section("Week-by-week breakdown (Mon–Sun, local time)")
 
+    # Fetch weekly active users: last sample per week gives WAU for that week
+    _end_ts = int(time.time())
+    _start_ts = _end_ts - args.days * 86400
+    _tz = ZoneInfo(args.timezone)
+    _au_vals = query_range(
+        args.url,
+        f'sum(max(jupyterhub_active_users{{period="7d", {ns_filter}}}) by (namespace))',
+        _start_ts,
+        _end_ts,
+        step=1800,
+    )
+    week_active_users = {}
+    for _ts, _val in _au_vals:
+        _dt = datetime.fromtimestamp(int(_ts), tz=_tz)
+        _wk = (_dt - timedelta(days=_dt.weekday())).strftime("%Y-%m-%d")
+        week_active_users[_wk] = int(float(_val))
+
     week_samples = defaultdict(list)
     for dt, v in samples:
         week_start = dt - timedelta(days=dt.weekday())
         week_samples[week_start.strftime("%Y-%m-%d")].append(v)
 
+    hrs_t_col = f"Hrs>{T}"
+    hrs_t2_col = f"Hrs>{T2}"
     print(
-        f"  {'Week of':<12} {'Peak':>5}  {'Avg':>5}  "
-        f"{'Hrs>{T}':>7}  {'Hrs>{T2}':>8}  Chart"
+        f"  {'Week of':<12} {'Peak':>5}  {'Active':>6}  "
+        f"{hrs_t_col:>7}  {hrs_t2_col:>8}  Chart"
     )
-    print(f"  {'-' * 12} {'-' * 5}  {'-' * 5}  {'-' * 7}  {'-' * 8}  -----")
+    print(f"  {'-' * 12} {'-' * 5}  {'-' * 6}  {'-' * 7}  {'-' * 8}  -----")
     for week in sorted(week_samples):
         s = week_samples[week]
         wpeak = max(s)
-        wavg = sum(s) / len(s)
+        active = week_active_users.get(week, 0)
         # each sample = 30 min
         hrs_t = sum(1 for v in s if v > T) * 0.5
         hrs_t2 = sum(1 for v in s if v > T2) * 0.5
         bar = "#" * (wpeak // 5)
         print(
-            f"  {week:<12} {wpeak:>5}  {wavg:>5.1f}  "
+            f"  {week:<12} {wpeak:>5}  {active:>6}  "
             f"{hrs_t:>6.1f}h  {hrs_t2:>7.1f}h  {bar}"
         )
         report["weeks"].append(
-            {"week": week, "peak": wpeak, "avg": wavg, "hrs_t": hrs_t, "hrs_t2": hrs_t2}
+            {
+                "week": week,
+                "peak": wpeak,
+                "active": active,
+                "hrs_t": hrs_t,
+                "hrs_t2": hrs_t2,
+            }
         )
 
     # -------------------------------------------------------------------------
@@ -496,7 +529,8 @@ def main(args):
     for dt, v in samples:
         hour_samples[dt.hour].append(v)
 
-    print(f"  {'Hour':<10} {'Peak':>5}  {'Avg':>5}  {'Pct>{T}':>8}  Chart")
+    pct_col = f"Pct>{T}"
+    print(f"  {'Hour':<10} {'Peak':>5}  {'Avg':>5}  {pct_col:>8}  Chart")
     print(f"  {'-' * 10} {'-' * 5}  {'-' * 5}  {'-' * 8}  -----")
     for h in range(24):
         s = hour_samples[h]
@@ -506,7 +540,7 @@ def main(args):
         havg = sum(s) / len(s)
         pct = sum(1 for v in s if v > T) / len(s) * 100
         bar = "#" * (hpeak // 5)
-        label = f"{h:02d}:00-{h + 1:02d}:00"
+        label = f"{h:02d}:00-{(h + 1) % 24:02d}:00"
         print(f"  {label:<10} {hpeak:>5}  {havg:>5.1f}  {pct:>7.1f}%  {bar}")
         report["hours"].append({"label": label, "peak": hpeak, "avg": havg, "pct": pct})
 
@@ -519,7 +553,7 @@ def main(args):
     for dt, v in samples:
         dow_samples[dt.weekday()].append(v)
 
-    print(f"  {'Day':<5} {'Peak':>5}  {'Avg':>5}  {'Pct>{T}':>8}  Chart")
+    print(f"  {'Day':<5} {'Peak':>5}  {'Avg':>5}  {pct_col:>8}  Chart")
     print(f"  {'-' * 5} {'-' * 5}  {'-' * 5}  {'-' * 8}  -----")
     for d in range(7):
         s = dow_samples[d]

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -15,7 +15,7 @@ Optional arguments:
     --threshold      User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
     --timezone       IANA timezone for local time display, should match hub users' location
                      (default: America/Los_Angeles)
-    --report-format  Write a report to scripts/reports/: text, markdown, or html (default: text)
+    --save-report    Optionally save a report to scripts/reports/: text, markdown (or md), or html
 """
 
 import argparse
@@ -347,10 +347,15 @@ def format_html(report):
 def write_report(report, fmt, script_dir):
     """Write a formatted report to scripts/reports/."""
     date_str = datetime.now().strftime("%Y-%m-%d")
-    ext = {"text": "txt", "markdown": "md", "html": "html"}[fmt]
+    ext = {"text": "txt", "markdown": "md", "md": "md", "html": "html"}[fmt]
     path = script_dir / "reports" / f"concurrent-users-{date_str}.{ext}"
 
-    formatters = {"text": format_text, "markdown": format_markdown, "html": format_html}
+    formatters = {
+        "text": format_text,
+        "markdown": format_markdown,
+        "md": format_markdown,
+        "html": format_html,
+    }
     path.write_text(formatters[fmt](report), encoding="utf-8")
     print(f"\nReport written to {path}")
 
@@ -517,7 +522,8 @@ def main(args):
     # -------------------------------------------------------------------------
     # Optional: write report to scripts/reports/
     # -------------------------------------------------------------------------
-    write_report(report, args.report_format, Path(__file__).parent)
+    if args.save_report:
+        write_report(report, args.save_report, Path(__file__).parent)
 
 
 if __name__ == "__main__":
@@ -549,9 +555,8 @@ if __name__ == "__main__":
         help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
     )
     parser.add_argument(
-        "--report-format",
-        choices=["text", "markdown", "html"],
-        default="text",
-        help="Write a report to scripts/reports/ in the specified format (default: text)",
+        "--save-report",
+        choices=["text", "markdown", "md", "html"],
+        help="Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)",
     )
     main(parser.parse_args())

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -10,17 +10,23 @@ Then run:
 
 Optional arguments:
     --days      Number of days to look back (default: 148)
-    --step      Query step interval (default: 5m)
+    --step      Query resolution step for instant queries (default: 5m)
     --url       Prometheus URL (default: http://localhost:9090)
     --threshold User count threshold for "above N users" stats (default: 80)
+    --tz-offset Hours offset from UTC for local time display (default: -7 for PDT)
 """
 
 import argparse
 import json
 import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
+
+DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
 
 def query(url, promql):
@@ -38,6 +44,60 @@ def query(url, promql):
         sys.exit(1)
 
 
+def query_range(url, promql, start, end, step):
+    """Run a Prometheus range query and return the list of (timestamp, value) pairs."""
+    params = urlencode({"query": promql, "start": start, "end": end, "step": step})
+    try:
+        with urlopen(f"{url}/api/v1/query_range?{params}") as resp:
+            data = json.load(resp)
+    except URLError as e:
+        print(f"Error connecting to Prometheus at {url}: {e}")
+        print(
+            "Is the port-forward running?\n"
+            "    kubectl -n support port-forward deployment/support-prometheus-server 9090"
+        )
+        sys.exit(1)
+
+    if data.get("status") != "success":
+        print(f"Prometheus error: {data.get('error', 'unknown')}")
+        sys.exit(1)
+
+    return data["data"]["result"][0]["values"]
+
+
+def get_range_samples(url, days, tz_offset_hours):
+    """
+    Fetch total running servers at 30m resolution over the given number of days.
+    Returns a list of (datetime_local, value) tuples.
+    """
+    end = int(time.time())
+    start = end - days * 86400
+    tz_offset_secs = tz_offset_hours * 3600
+
+    # 148 days at 30m = ~7104 samples, well within the 11000-point limit
+    values = query_range(
+        url,
+        'sum(jupyterhub_running_servers{namespace=~".*-prod"})',
+        start,
+        end,
+        step=1800,
+    )
+
+    samples = []
+    for ts, val in values:
+        v = max(int(float(val)), 0)  # clamp negatives from counter resets
+        local_ts = int(ts) + tz_offset_secs
+        dt = datetime.fromtimestamp(local_ts, tz=timezone.utc)
+        samples.append((dt, v))
+    return samples
+
+
+def section(title):
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -46,7 +106,9 @@ def main():
         "--days", type=int, default=148, help="Days to look back (default: 148)"
     )
     parser.add_argument(
-        "--step", default="5m", help="Query resolution step (default: 5m)"
+        "--step",
+        default="5m",
+        help="Query resolution step for instant queries (default: 5m)",
     )
     parser.add_argument(
         "--url",
@@ -57,40 +119,55 @@ def main():
         "--threshold",
         type=int,
         default=80,
-        help="User count threshold for percentage stats (default: 80)",
+        help="User count threshold for percentage/hours stats (default: 80)",
+    )
+    parser.add_argument(
+        "--tz-offset",
+        type=int,
+        default=-7,
+        help="Hours offset from UTC for local time display (default: -7 for PDT)",
     )
     args = parser.parse_args()
 
     window = f"{args.days}d"
     subquery = f"[{window}:{args.step}]"
     ns_filter = 'namespace=~".*-prod"'
+    T = args.threshold
+    T2 = T + 40
 
-    print(f"Querying {args.url} over the last {args.days} days (step={args.step})\n")
+    print(f"Querying {args.url} over the last {args.days} days")
+    print(f"Threshold: {T} users  |  UTC offset: {args.tz_offset:+d}h\n")
 
-    # --- 1. Overall peak ---
+    # -------------------------------------------------------------------------
+    # Section 1: Overall peak + time-above-threshold
+    # -------------------------------------------------------------------------
+    section(f"Overall statistics (last {args.days} days)")
+
     data = query(
         args.url,
         f"max_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
     )
     peak = int(data["data"]["result"][0]["value"][1])
-    print(f"Peak concurrent users (all hubs): {peak}")
+    print(f"  Peak concurrent users (all hubs): {peak}")
 
-    # --- 2. Fraction of time above threshold ---
-    for n in [args.threshold, args.threshold + 40]:
+    for n in [T, T2]:
         data = query(
             args.url,
             f"sum_over_time((sum(jupyterhub_running_servers{{{ns_filter}}}) > bool {n}){subquery})"
             f" / count_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
         )
         frac = float(data["data"]["result"][0]["value"][1])
-        total_minutes = args.days * 24 * 60
-        minutes_above = frac * total_minutes
-        hours_above = minutes_above / 60
+        hours_above = frac * args.days * 24
         print(
-            f"Fraction of time above {n} users: {frac:.4f} ({frac * 100:.2f}%) ~= {hours_above:.1f} hours"
+            f"  Fraction of time above {n:>3} users: "
+            f"{frac * 100:5.2f}%  (~{hours_above:.1f} hours total)"
         )
 
-    # --- 3. Per-hub peak (deduplicated) ---
+    # -------------------------------------------------------------------------
+    # Section 2: Per-hub peak
+    # -------------------------------------------------------------------------
+    section(f"Per-hub peak concurrent users (last {args.days} days)")
+
     data = query(
         args.url, f"max_over_time(jupyterhub_running_servers{{{ns_filter}}}{subquery})"
     )
@@ -101,14 +178,89 @@ def main():
         if val > hubs.get(ns, 0):
             hubs[ns] = val
 
-    print(f"\nPer-hub peak concurrent users (top hubs, last {args.days} days):")
-    print(f"  {'Hub':<28} {'Peak':>6}  Chart")
-    print(f"  {'-' * 28} {'-' * 6}  -----")
+    print(f"  {'Hub':<28} {'Peak':>5}  Chart")
+    print(f"  {'-' * 28} {'-' * 5}  -----")
     for hub, val in sorted(hubs.items(), key=lambda x: -x[1]):
         if val == 0:
             continue
         bar = "#" * (val // 5)
-        print(f"  {hub:<28} {val:>6}  {bar}")
+        print(f"  {hub:<28} {val:>5}  {bar}")
+
+    # -------------------------------------------------------------------------
+    # Fetch range data once for the remaining analyses (30m resolution)
+    # -------------------------------------------------------------------------
+    samples = get_range_samples(args.url, args.days, args.tz_offset)
+
+    # -------------------------------------------------------------------------
+    # Section 3: Week-by-week breakdown
+    # -------------------------------------------------------------------------
+    section("Week-by-week breakdown (Mon–Sun, local time)")
+
+    week_samples = defaultdict(list)
+    for dt, v in samples:
+        week_start = dt - timedelta(days=dt.weekday())
+        week_samples[week_start.strftime("%Y-%m-%d")].append(v)
+
+    print(
+        f"  {'Week of':<12} {'Peak':>5}  {'Avg':>5}  "
+        f"{'Hrs>{T}':>7}  {'Hrs>{T2}':>8}  Chart"
+    )
+    print(f"  {'-' * 12} {'-' * 5}  {'-' * 5}  {'-' * 7}  {'-' * 8}  -----")
+    for week in sorted(week_samples):
+        s = week_samples[week]
+        wpeak = max(s)
+        wavg = sum(s) / len(s)
+        # each sample = 30 min
+        hrs_t = sum(1 for v in s if v > T) * 0.5
+        hrs_t2 = sum(1 for v in s if v > T2) * 0.5
+        bar = "#" * (wpeak // 5)
+        print(
+            f"  {week:<12} {wpeak:>5}  {wavg:>5.1f}  "
+            f"{hrs_t:>6.1f}h  {hrs_t2:>7.1f}h  {bar}"
+        )
+
+    # -------------------------------------------------------------------------
+    # Section 4: Hour-of-day breakdown
+    # -------------------------------------------------------------------------
+    section("Concurrent users by hour of day (local time)")
+
+    hour_samples = defaultdict(list)
+    for dt, v in samples:
+        hour_samples[dt.hour].append(v)
+
+    print(f"  {'Hour':<10} {'Peak':>5}  {'Avg':>5}  {'Pct>{T}':>8}  Chart")
+    print(f"  {'-' * 10} {'-' * 5}  {'-' * 5}  {'-' * 8}  -----")
+    for h in range(24):
+        s = hour_samples[h]
+        if not s:
+            continue
+        hpeak = max(s)
+        havg = sum(s) / len(s)
+        pct = sum(1 for v in s if v > T) / len(s) * 100
+        bar = "#" * (hpeak // 5)
+        label = f"{h:02d}:00-{h + 1:02d}:00"
+        print(f"  {label:<10} {hpeak:>5}  {havg:>5.1f}  {pct:>7.1f}%  {bar}")
+
+    # -------------------------------------------------------------------------
+    # Section 5: Day-of-week breakdown
+    # -------------------------------------------------------------------------
+    section("Concurrent users by day of week (local time)")
+
+    dow_samples = defaultdict(list)
+    for dt, v in samples:
+        dow_samples[dt.weekday()].append(v)
+
+    print(f"  {'Day':<5} {'Peak':>5}  {'Avg':>5}  {'Pct>{T}':>8}  Chart")
+    print(f"  {'-' * 5} {'-' * 5}  {'-' * 5}  {'-' * 8}  -----")
+    for d in range(7):
+        s = dow_samples[d]
+        if not s:
+            continue
+        dpeak = max(s)
+        davg = sum(s) / len(s)
+        pct = sum(1 for v in s if v > T) / len(s) * 100
+        bar = "#" * (dpeak // 5)
+        print(f"  {DAYS_OF_WEEK[d]:<5} {dpeak:>5}  {davg:>5.1f}  {pct:>7.1f}%  {bar}")
 
 
 if __name__ == "__main__":

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -715,4 +715,6 @@ if __name__ == "__main__":
     if config_defaults:
         parser.set_defaults(**config_defaults)
 
-    main(parser.parse_args())
+    args = parser.parse_args()
+
+    main(args)

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -33,8 +33,8 @@ Optional arguments:
     --namespace-pattern   Prometheus regex to match hub namespaces (default: .*-prod)
     --save-report         Optionally save a report to scripts/reports/: text,
                           markdown (or md), or html
-    --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
-                          explicit CLI args always win.
+    --config              Path to a YAML config file. Any key matching a CLI
+                          arg sets its default; explicit CLI args always win.
     --debug               Print each Prometheus query and sample counts as the script runs.
 
 Two independent resolutions are used per run:
@@ -169,6 +169,7 @@ def get_range_samples(
 
 
 def section(title):
+    """Print a titled section header to stdout."""
     print(f"\n{'=' * 60}")
     print(f"  {title}")
     print(f"{'=' * 60}")
@@ -178,13 +179,13 @@ def format_text(report):
     """Render report data as plain text (mirrors stdout output)."""
     T = report["threshold"]
     T2 = report["threshold2"]
-    rl = report["range_label"]
+    range_label = report["range_label"]
     lines = []
 
     lines.append("JupyterHub Concurrent User Report")
     lines.append(f"Generated: {report['generated']}")
     lines.append(
-        f"Range: {rl}  |  Thresholds: {T}, {T2} users per node"
+        f"Range: {range_label}  |  Thresholds: {T}, {T2} users per node"
         f"  |  Namespace: {report['namespace_pattern']}  |  Timezone: {report['timezone']}"
     )
     lines.append(
@@ -199,7 +200,7 @@ def format_text(report):
     )
 
     lines.append(f"\n{'=' * 60}")
-    lines.append(f"  Overall statistics ({rl})")
+    lines.append(f"  Overall statistics ({range_label})")
     lines.append(f"{'=' * 60}")
     lines.append(f"  Peak concurrent users (all hubs): {report['overall']['peak']}")
     for a in report["overall"]["above"]:
@@ -209,7 +210,7 @@ def format_text(report):
         )
 
     lines.append(f"\n{'=' * 60}")
-    lines.append(f"  Per-namespace peak concurrent users ({rl})")
+    lines.append(f"  Per-namespace peak concurrent users ({range_label})")
     lines.append(f"{'=' * 60}")
     lines.append(f"  {'Namespace':<28} {'Peak':>5}  Chart")
     lines.append(f"  {'-' * 28} {'-' * 5}  -----")
@@ -269,14 +270,14 @@ def format_markdown(report):
     """Render report data as Markdown."""
     T = report["threshold"]
     T2 = report["threshold2"]
-    rl = report["range_label"]
+    range_label = report["range_label"]
     lines = []
 
     lines.append("# JupyterHub Concurrent User Report")
     lines.append("")
     lines.append(f"**Generated:** {report['generated']}  ")
     lines.append(
-        f"**Range:** {rl}  |  "
+        f"**Range:** {range_label}  |  "
         f"**Thresholds:** {T}, {T2} users per node  |  "
         f"**Namespace:** {report['namespace_pattern']}  |  "
         f"**Timezone:** {report['timezone']}"
@@ -301,7 +302,7 @@ def format_markdown(report):
     lines.append("| Chart | Bar chart; each # = 5 users |")
     lines.append("")
 
-    lines.append(f"## Overall statistics ({rl})")
+    lines.append(f"## Overall statistics ({range_label})")
     lines.append("")
     lines.append("| Metric | Value |")
     lines.append("|---|---|")
@@ -313,7 +314,7 @@ def format_markdown(report):
         )
     lines.append("")
 
-    lines.append(f"## Per-namespace peak concurrent users ({rl})")
+    lines.append(f"## Per-namespace peak concurrent users ({range_label})")
     lines.append("")
     lines.append("| Namespace | Peak |")
     lines.append("|---|---|")
@@ -360,7 +361,7 @@ def format_html(report):
     """Render report data as a self-contained HTML document."""
     T = report["threshold"]
     T2 = report["threshold2"]
-    rl = report["range_label"]
+    range_label = report["range_label"]
 
     def th(*cells):
         return "<tr>" + "".join(f"<th>{c}</th>" for c in cells) + "</tr>"
@@ -392,7 +393,7 @@ def format_html(report):
 <h1>JupyterHub Concurrent User Report</h1>
 <p class="meta">
   Generated: {report["generated"]} &nbsp;|&nbsp;
-  Range: {rl} &nbsp;|&nbsp;
+  Range: {range_label} &nbsp;|&nbsp;
   Thresholds: {T}, {T2} users per node &nbsp;|&nbsp;
   Namespace: {report["namespace_pattern"]} &nbsp;|&nbsp;
   Timezone: {report["timezone"]}
@@ -412,7 +413,7 @@ def format_html(report):
         f"</table>"
     )
 
-    parts.append(f"<h2>Overall statistics ({rl})</h2><table>")
+    parts.append(f"<h2>Overall statistics ({range_label})</h2><table>")
     parts.append(th("Metric", "Value"))
     parts.append(
         td("Peak concurrent users", f"<strong>{report['overall']['peak']}</strong>")
@@ -426,7 +427,7 @@ def format_html(report):
         )
     parts.append("</table>")
 
-    parts.append(f"<h2>Per-namespace peak concurrent users ({rl})</h2><table>")
+    parts.append(f"<h2>Per-namespace peak concurrent users ({range_label})</h2><table>")
     parts.append(th("Namespace", "Peak", "Chart"))
     for hub, val in report["hubs"]:
         bar = "#" * (val // 5)
@@ -677,11 +678,11 @@ def main(args):
                 "  [debug] fetching weekly active users (jupyterhub_active_users{period='7d'})"
             )
             print(f"  [debug]   {wau_promql}")
-        _au_vals = query_range(args.url, wau_promql, start_ts, end_ts, step=1800)
-        for _ts, _val in _au_vals:
-            _dt = datetime.fromtimestamp(int(_ts), tz=tz)
-            _wk = (_dt - timedelta(days=_dt.weekday())).strftime("%Y-%m-%d")
-            week_active_users[_wk] = int(float(_val))
+        au_vals = query_range(args.url, wau_promql, start_ts, end_ts, step=1800)
+        for ts, val in au_vals:
+            dt = datetime.fromtimestamp(int(ts), tz=tz)
+            week_key = (dt - timedelta(days=dt.weekday())).strftime("%Y-%m-%d")
+            week_active_users[week_key] = int(float(val))
         if args.debug:
             print(f"  [debug] got WAU data for {len(week_active_users)} weeks")
     elif args.debug:
@@ -856,7 +857,10 @@ if __name__ == "__main__":
         "-r",
         "--save-report",
         choices=["text", "markdown", "md", "html"],
-        help="Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)",
+        help=(
+            "Save a report to scripts/reports/ in the specified format "
+            "(md and markdown are equivalent)"
+        ),
     )
     parser.add_argument(
         "--debug",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -13,7 +13,8 @@ Optional arguments:
     --step           Query resolution step for instant queries (default: 5m)
     --url            Prometheus URL (default: http://localhost:9090)
     --threshold      User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
-    --tz-offset      Hours offset from UTC for local time display (default: auto-detected from system timezone)
+    --timezone       IANA timezone for local time display, should match hub users' location
+                     (default: America/Los_Angeles)
     --report-format  Write a report to scripts/reports/: text, markdown, or html (default: text)
 """
 
@@ -27,6 +28,7 @@ from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
+from zoneinfo import ZoneInfo
 
 DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
@@ -67,14 +69,14 @@ def query_range(url, promql, start, end, step):
     return data["data"]["result"][0]["values"]
 
 
-def get_range_samples(url, days, tz_offset_hours):
+def get_range_samples(url, days, tz_name):
     """
     Fetch total running servers at 30m resolution over the given number of days.
-    Returns a list of (datetime_local, value) tuples.
+    Returns a list of (datetime_local, value) tuples, converted to tz_name.
     """
     end = int(time.time())
     start = end - days * 86400
-    tz_offset_secs = tz_offset_hours * 3600
+    tz = ZoneInfo(tz_name)
 
     # 148 days at 30m = ~7104 samples, well within the 11000-point limit
     values = query_range(
@@ -88,8 +90,7 @@ def get_range_samples(url, days, tz_offset_hours):
     samples = []
     for ts, val in values:
         v = max(int(float(val)), 0)  # clamp negatives from counter resets
-        local_ts = int(ts) + tz_offset_secs
-        dt = datetime.fromtimestamp(local_ts, tz=timezone.utc)
+        dt = datetime.fromtimestamp(int(ts), tz=tz)
         samples.append((dt, v))
     return samples
 
@@ -111,7 +112,7 @@ def format_text(report):
     lines.append(f"Generated: {report['generated']}")
     lines.append(
         f"Range: last {days} days  |  Threshold: {T} users"
-        f"  |  UTC offset: {report['tz_offset']:+d}h"
+        f"  |  Timezone: {report['timezone']}"
     )
 
     lines.append(f"\n{'=' * 60}")
@@ -191,7 +192,7 @@ def format_markdown(report):
     lines.append(
         f"**Range:** last {days} days  |  "
         f"**Threshold:** {T} users  |  "
-        f"**UTC offset:** {report['tz_offset']:+d}h"
+        f"**Timezone:** {report['timezone']}"
     )
     lines.append("")
 
@@ -286,7 +287,7 @@ def format_html(report):
   Generated: {report["generated"]} &nbsp;|&nbsp;
   Range: last {days} days &nbsp;|&nbsp;
   Threshold: {T} users &nbsp;|&nbsp;
-  UTC offset: {report["tz_offset"]:+d}h
+  Timezone: {report["timezone"]}
 </p>"""
     )
 
@@ -355,8 +356,6 @@ def write_report(report, fmt, script_dir):
 
 
 def main():
-    tz_default = int(datetime.now().astimezone().utcoffset().total_seconds() // 3600)
-
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -380,10 +379,9 @@ def main():
         help="User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.",
     )
     parser.add_argument(
-        "--tz-offset",
-        type=int,
-        default=tz_default,
-        help=f"Hours offset from UTC for local time display (default: auto-detected as {tz_default:+d}h)",
+        "--timezone",
+        default="America/Los_Angeles",
+        help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
     )
     parser.add_argument(
         "--report-format",
@@ -400,14 +398,14 @@ def main():
     T2 = T + 40
 
     print(f"Querying {args.url} over the last {args.days} days")
-    print(f"Threshold: {T} users  |  UTC offset: {args.tz_offset:+d}h\n")
+    print(f"Threshold: {T} users  |  Timezone: {args.timezone}\n")
 
     report = {
         "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         "days": args.days,
         "threshold": T,
         "threshold2": T2,
-        "tz_offset": args.tz_offset,
+        "timezone": args.timezone,
         "overall": {"peak": None, "above": []},
         "hubs": [],
         "weeks": [],
@@ -471,7 +469,7 @@ def main():
     # -------------------------------------------------------------------------
     # Fetch range data once for the remaining analyses (30m resolution)
     # -------------------------------------------------------------------------
-    samples = get_range_samples(args.url, args.days, args.tz_offset)
+    samples = get_range_samples(args.url, args.days, args.timezone)
 
     # -------------------------------------------------------------------------
     # Section 3: Week-by-week breakdown

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -531,7 +531,7 @@ if __name__ == "__main__":
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--days", type=int, default=148, help="Days to look back (default: 148)"
+        "-d", "--days", type=int, default=148, help="Days to look back (default: 148)"
     )
     parser.add_argument(
         "--step",
@@ -539,22 +539,26 @@ if __name__ == "__main__":
         help="Query resolution step for instant queries (default: 5m)",
     )
     parser.add_argument(
+        "-u",
         "--url",
         default="http://localhost:9090",
         help="Prometheus URL (default: http://localhost:9090)",
     )
     parser.add_argument(
+        "-t",
         "--threshold",
         type=int,
         default=80,
         help="User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.",
     )
     parser.add_argument(
+        "-z",
         "--timezone",
         default="America/Los_Angeles",
         help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
     )
     parser.add_argument(
+        "-r",
         "--save-report",
         choices=["text", "markdown", "md", "html"],
         help="Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -18,7 +18,7 @@ Optional arguments:
     --namespace-pattern   Prometheus regex to match hub namespaces (default: .*-prod)
     --save-report         Optionally save a report to scripts/reports/: text, markdown (or md), or html
     --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
-                          explicit CLI args always win. Requires ruamel.yaml (pip install ruamel.yaml).
+                          explicit CLI args always win.
 
 Example config file (my-deployment.yaml):
     namespace_pattern: ".*-staging"

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -655,7 +655,6 @@ if __name__ == "__main__":
         help="Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)",
     )
     parser.add_argument(
-        "-d",
         "--debug",
         action="store_true",
         help="Print each Prometheus query and sample counts as the script runs",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -5,9 +5,9 @@ Query Prometheus for concurrent JupyterHub user statistics across all prod hubs.
 Requires an active port-forward to the Prometheus server:
     kubectl -n support port-forward deployment/support-prometheus-server 9090
 
-kubectl will print "Handling connection for 9090" to stderr for each request.
-To suppress it, redirect stderr when starting the port-forward:
-    kubectl -n support port-forward deployment/support-prometheus-server 9090 2>/dev/null &
+kubectl will print "Handling connection for 9090" to stdout for each request.
+To suppress it, redirect both stdout and stderr when starting the port-forward:
+    kubectl -n support port-forward deployment/support-prometheus-server 9090 >/dev/null 2>&1 &
 
 Then run:
     python3 scripts/query_concurrent_users.py
@@ -59,7 +59,7 @@ def query(url, promql):
         print(f"Error connecting to Prometheus at {url}: {e}")
         print(
             "Is the port-forward running?\n"
-            "    kubectl -n support port-forward deployment/support-prometheus-server 9090"
+            "    kubectl -n support port-forward deployment/support-prometheus-server 9090 >/dev/null 2>&1 &"
         )
         sys.exit(1)
 
@@ -74,7 +74,7 @@ def query_range(url, promql, start, end, step):
         print(f"Error connecting to Prometheus at {url}: {e}")
         print(
             "Is the port-forward running?\n"
-            "    kubectl -n support port-forward deployment/support-prometheus-server 9090"
+            "    kubectl -n support port-forward deployment/support-prometheus-server 9090 >/dev/null 2>&1 &"
         )
         sys.exit(1)
 

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -2,7 +2,8 @@
 """
 Query Prometheus for concurrent JupyterHub user statistics across all prod hubs.
 
-Requires an active port-forward to the Prometheus server:
+Requires an active port-forward to the Prometheus server (you may need to change
+the namespace or deployment name if your setup differs):
     kubectl -n support port-forward deployment/support-prometheus-server 9090
 
 kubectl will print "Handling connection for 9090" to stdout for each request.
@@ -25,11 +26,13 @@ Optional arguments:
                           window. Does not affect the time-series data returned for the
                           hourly/daily/weekly breakdown tables. (default: 5m)
     --url                 Prometheus URL (default: http://localhost:9090)
-    --threshold           User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
+    --threshold           User count threshold for "above N users" stats (default: 80).
+                          Roughly the total users a single node with ~64GB RAM can support.
     --timezone            IANA timezone for local time display, should match hub users' location
                           (default: America/Los_Angeles)
     --namespace-pattern   Prometheus regex to match hub namespaces (default: .*-prod)
-    --save-report         Optionally save a report to scripts/reports/: text, markdown (or md), or html
+    --save-report         Optionally save a report to scripts/reports/: text,
+                          markdown (or md), or html
     --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
                           explicit CLI args always win.
     --debug               Print each Prometheus query and sample counts as the script runs.
@@ -68,7 +71,7 @@ Examples:
     python3 scripts/query_concurrent_users.py \\
         --start "2026-02-01" --end "2026-03-01"
 
-    # Midterm week deep-dive — 5-day span, 5-minute sample interval for maximum granularity
+    # Midterm week deep-dive — 5-day span, 5-minute sample interval for max granularity
     python3 scripts/query_concurrent_users.py \\
         --start "2026-03-09 00:00" --end "2026-03-13 23:59"
 
@@ -831,13 +834,19 @@ if __name__ == "__main__":
         "--threshold",
         type=int,
         default=80,
-        help="User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.",
+        help=(
+            "User count threshold for percentage/hours stats (default: 80). "
+            "Roughly the total users a single node with ~64GB RAM can support."
+        ),
     )
     parser.add_argument(
         "-z",
         "--timezone",
         default="America/Los_Angeles",
-        help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
+        help=(
+            "IANA timezone for local time display, should match hub users' location "
+            "(default: America/Los_Angeles)"
+        ),
     )
     parser.add_argument(
         "-n",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -13,7 +13,7 @@ Optional arguments:
     --step           Query resolution step for instant queries (default: 5m)
     --url            Prometheus URL (default: http://localhost:9090)
     --threshold      User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
-    --tz-offset      Hours offset from UTC for local time display (default: -7 for PDT)
+    --tz-offset      Hours offset from UTC for local time display (default: auto-detected from system timezone)
     --report-format  Write a report to scripts/reports/: text, markdown, or html (default: text)
 """
 
@@ -355,6 +355,8 @@ def write_report(report, fmt, script_dir):
 
 
 def main():
+    tz_default = int(datetime.now().astimezone().utcoffset().total_seconds() // 3600)
+
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -380,8 +382,8 @@ def main():
     parser.add_argument(
         "--tz-offset",
         type=int,
-        default=-7,
-        help="Hours offset from UTC for local time display (default: -7 for PDT)",
+        default=tz_default,
+        help=f"Hours offset from UTC for local time display (default: auto-detected as {tz_default:+d}h)",
     )
     parser.add_argument(
         "--report-format",

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Query Prometheus for concurrent JupyterHub user statistics across all prod hubs.
+
+Requires an active port-forward to the Prometheus server:
+    kubectl -n support port-forward deployment/support-prometheus-server 9090
+
+Then run:
+    python3 scripts/query_concurrent_users.py
+
+Optional arguments:
+    --days      Number of days to look back (default: 148)
+    --step      Query step interval (default: 5m)
+    --url       Prometheus URL (default: http://localhost:9090)
+    --threshold User count threshold for "above N users" stats (default: 80)
+"""
+
+import argparse
+import json
+import sys
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+
+def query(url, promql):
+    """Run an instant Prometheus query and return parsed JSON."""
+    params = urlencode({"query": promql})
+    try:
+        with urlopen(f"{url}/api/v1/query?{params}") as resp:
+            return json.load(resp)
+    except URLError as e:
+        print(f"Error connecting to Prometheus at {url}: {e}")
+        print(
+            "Is the port-forward running?\n"
+            "    kubectl -n support port-forward deployment/support-prometheus-server 9090"
+        )
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--days", type=int, default=148, help="Days to look back (default: 148)"
+    )
+    parser.add_argument(
+        "--step", default="5m", help="Query resolution step (default: 5m)"
+    )
+    parser.add_argument(
+        "--url",
+        default="http://localhost:9090",
+        help="Prometheus URL (default: http://localhost:9090)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=80,
+        help="User count threshold for percentage stats (default: 80)",
+    )
+    args = parser.parse_args()
+
+    window = f"{args.days}d"
+    subquery = f"[{window}:{args.step}]"
+    ns_filter = 'namespace=~".*-prod"'
+
+    print(f"Querying {args.url} over the last {args.days} days (step={args.step})\n")
+
+    # --- 1. Overall peak ---
+    data = query(
+        args.url,
+        f"max_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
+    )
+    peak = int(data["data"]["result"][0]["value"][1])
+    print(f"Peak concurrent users (all hubs): {peak}")
+
+    # --- 2. Fraction of time above threshold ---
+    for n in [args.threshold, args.threshold + 40]:
+        data = query(
+            args.url,
+            f"sum_over_time((sum(jupyterhub_running_servers{{{ns_filter}}}) > bool {n}){subquery})"
+            f" / count_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
+        )
+        frac = float(data["data"]["result"][0]["value"][1])
+        total_minutes = args.days * 24 * 60
+        minutes_above = frac * total_minutes
+        hours_above = minutes_above / 60
+        print(
+            f"Fraction of time above {n} users: {frac:.4f} ({frac * 100:.2f}%) ~= {hours_above:.1f} hours"
+        )
+
+    # --- 3. Per-hub peak (deduplicated) ---
+    data = query(
+        args.url, f"max_over_time(jupyterhub_running_servers{{{ns_filter}}}{subquery})"
+    )
+    hubs = {}
+    for r in data["data"]["result"]:
+        ns = r["metric"].get("namespace", "unknown")
+        val = int(r["value"][1])
+        if val > hubs.get(ns, 0):
+            hubs[ns] = val
+
+    print(f"\nPer-hub peak concurrent users (top hubs, last {args.days} days):")
+    print(f"  {'Hub':<28} {'Peak':>6}  Chart")
+    print(f"  {'-' * 28} {'-' * 6}  -----")
+    for hub, val in sorted(hubs.items(), key=lambda x: -x[1]):
+        if val == 0:
+            continue
+        bar = "#" * (val // 5)
+        print(f"  {hub:<28} {val:>6}  {bar}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -19,6 +19,7 @@ Optional arguments:
 """
 
 import argparse
+import calendar
 import json
 import sys
 import time
@@ -30,7 +31,7 @@ from urllib.parse import urlencode
 from urllib.request import urlopen
 from zoneinfo import ZoneInfo
 
-DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+DAYS_OF_WEEK = list(calendar.day_abbr)
 
 
 def query(url, promql):

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -121,8 +121,7 @@ def prom_query(url, promql, time=None):
     except URLError as e:
         print(f"Error connecting to Prometheus at {url}: {e}")
         print(
-            "Is the port-forward running?\n"
-            "    kubectl -n support port-forward deployment/support-prometheus-server 9090 >/dev/null 2>&1 &"
+            "Is the port-forward to Prometheus running? See the docstring for setup instructions."
         )
         sys.exit(1)
 
@@ -136,8 +135,7 @@ def query_range(url, promql, start, end, step):
     except URLError as e:
         print(f"Error connecting to Prometheus at {url}: {e}")
         print(
-            "Is the port-forward running?\n"
-            "    kubectl -n support port-forward deployment/support-prometheus-server 9090 >/dev/null 2>&1 &"
+            "Is the port-forward to Prometheus running? See the docstring for setup instructions."
         )
         sys.exit(1)
 

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -355,42 +355,7 @@ def write_report(report, fmt, script_dir):
     print(f"\nReport written to {path}")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-    parser.add_argument(
-        "--days", type=int, default=148, help="Days to look back (default: 148)"
-    )
-    parser.add_argument(
-        "--step",
-        default="5m",
-        help="Query resolution step for instant queries (default: 5m)",
-    )
-    parser.add_argument(
-        "--url",
-        default="http://localhost:9090",
-        help="Prometheus URL (default: http://localhost:9090)",
-    )
-    parser.add_argument(
-        "--threshold",
-        type=int,
-        default=80,
-        help="User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.",
-    )
-    parser.add_argument(
-        "--timezone",
-        default="America/Los_Angeles",
-        help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
-    )
-    parser.add_argument(
-        "--report-format",
-        choices=["text", "markdown", "html"],
-        default="text",
-        help="Write a report to scripts/reports/ in the specified format (default: text)",
-    )
-    args = parser.parse_args()
-
+def main(args):
     window = f"{args.days}d"
     subquery = f"[{window}:{args.step}]"
     ns_filter = 'namespace=~".*-prod"'
@@ -556,4 +521,37 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--days", type=int, default=148, help="Days to look back (default: 148)"
+    )
+    parser.add_argument(
+        "--step",
+        default="5m",
+        help="Query resolution step for instant queries (default: 5m)",
+    )
+    parser.add_argument(
+        "--url",
+        default="http://localhost:9090",
+        help="Prometheus URL (default: http://localhost:9090)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=80,
+        help="User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="America/Los_Angeles",
+        help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
+    )
+    parser.add_argument(
+        "--report-format",
+        choices=["text", "markdown", "html"],
+        default="text",
+        help="Write a report to scripts/reports/ in the specified format (default: text)",
+    )
+    main(parser.parse_args())

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -9,11 +9,12 @@ Then run:
     python3 scripts/query_concurrent_users.py
 
 Optional arguments:
-    --days      Number of days to look back (default: 148)
-    --step      Query resolution step for instant queries (default: 5m)
-    --url       Prometheus URL (default: http://localhost:9090)
-    --threshold User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
-    --tz-offset Hours offset from UTC for local time display (default: -7 for PDT)
+    --days           Number of days to look back (default: 148)
+    --step           Query resolution step for instant queries (default: 5m)
+    --url            Prometheus URL (default: http://localhost:9090)
+    --threshold      User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
+    --tz-offset      Hours offset from UTC for local time display (default: -7 for PDT)
+    --report-format  Write a report to scripts/reports/: text, markdown, or html (default: text)
 """
 
 import argparse
@@ -22,6 +23,7 @@ import sys
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
@@ -98,6 +100,260 @@ def section(title):
     print(f"{'=' * 60}")
 
 
+def format_text(report):
+    """Render report data as plain text (mirrors stdout output)."""
+    days = report["days"]
+    T = report["threshold"]
+    T2 = report["threshold2"]
+    lines = []
+
+    lines.append("Cal-ICOR JupyterHub Concurrent User Report")
+    lines.append(f"Generated: {report['generated']}")
+    lines.append(
+        f"Range: last {days} days  |  Threshold: {T} users"
+        f"  |  UTC offset: {report['tz_offset']:+d}h"
+    )
+
+    lines.append(f"\n{'=' * 60}")
+    lines.append(f"  Overall statistics (last {days} days)")
+    lines.append(f"{'=' * 60}")
+    lines.append(f"  Peak concurrent users (all hubs): {report['overall']['peak']}")
+    for a in report["overall"]["above"]:
+        lines.append(
+            f"  Fraction of time above {a['n']:>3} users: "
+            f"{a['pct']:5.2f}%  (~{a['hours']:.1f} hours total)"
+        )
+
+    lines.append(f"\n{'=' * 60}")
+    lines.append(f"  Per-hub peak concurrent users (last {days} days)")
+    lines.append(f"{'=' * 60}")
+    lines.append(f"  {'Hub':<28} {'Peak':>5}  Chart")
+    lines.append(f"  {'-' * 28} {'-' * 5}  -----")
+    for hub, val in report["hubs"]:
+        bar = "#" * (val // 5)
+        lines.append(f"  {hub:<28} {val:>5}  {bar}")
+
+    hrs_t_col = f"Hrs>{T}"
+    hrs_t2_col = f"Hrs>{T2}"
+    lines.append(f"\n{'=' * 60}")
+    lines.append("  Week-by-week breakdown (Mon-Sun, local time)")
+    lines.append(f"{'=' * 60}")
+    lines.append(
+        f"  {'Week of':<12} {'Peak':>5}  {'Avg':>5}  "
+        f"{hrs_t_col:>7}  {hrs_t2_col:>8}  Chart"
+    )
+    lines.append(f"  {'-' * 12} {'-' * 5}  {'-' * 5}  {'-' * 7}  {'-' * 8}  -----")
+    for w in report["weeks"]:
+        bar = "#" * (w["peak"] // 5)
+        lines.append(
+            f"  {w['week']:<12} {w['peak']:>5}  {w['avg']:>5.1f}  "
+            f"{w['hrs_t']:>6.1f}h  {w['hrs_t2']:>7.1f}h  {bar}"
+        )
+
+    pct_col = f"Pct>{T}"
+    lines.append(f"\n{'=' * 60}")
+    lines.append("  Concurrent users by hour of day (local time)")
+    lines.append(f"{'=' * 60}")
+    lines.append(f"  {'Hour':<10} {'Peak':>5}  {'Avg':>5}  {pct_col:>8}  Chart")
+    lines.append(f"  {'-' * 10} {'-' * 5}  {'-' * 5}  {'-' * 8}  -----")
+    for h in report["hours"]:
+        bar = "#" * (h["peak"] // 5)
+        lines.append(
+            f"  {h['label']:<10} {h['peak']:>5}  {h['avg']:>5.1f}"
+            f"  {h['pct']:>7.1f}%  {bar}"
+        )
+
+    lines.append(f"\n{'=' * 60}")
+    lines.append("  Concurrent users by day of week (local time)")
+    lines.append(f"{'=' * 60}")
+    lines.append(f"  {'Day':<5} {'Peak':>5}  {'Avg':>5}  {pct_col:>8}  Chart")
+    lines.append(f"  {'-' * 5} {'-' * 5}  {'-' * 5}  {'-' * 8}  -----")
+    for dow in report["days_of_week"]:
+        bar = "#" * (dow["peak"] // 5)
+        lines.append(
+            f"  {dow['label']:<5} {dow['peak']:>5}  {dow['avg']:>5.1f}"
+            f"  {dow['pct']:>7.1f}%  {bar}"
+        )
+
+    return "\n".join(lines)
+
+
+def format_markdown(report):
+    """Render report data as Markdown."""
+    days = report["days"]
+    T = report["threshold"]
+    T2 = report["threshold2"]
+    lines = []
+
+    lines.append("# Cal-ICOR JupyterHub Concurrent User Report")
+    lines.append("")
+    lines.append(f"**Generated:** {report['generated']}  ")
+    lines.append(
+        f"**Range:** last {days} days  |  "
+        f"**Threshold:** {T} users  |  "
+        f"**UTC offset:** {report['tz_offset']:+d}h"
+    )
+    lines.append("")
+
+    lines.append(f"## Overall statistics (last {days} days)")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Peak concurrent users | **{report['overall']['peak']}** |")
+    for a in report["overall"]["above"]:
+        lines.append(
+            f"| Fraction of time above {a['n']} users"
+            f" | {a['pct']:.2f}% (~{a['hours']:.1f} hours) |"
+        )
+    lines.append("")
+
+    lines.append(f"## Per-hub peak concurrent users (last {days} days)")
+    lines.append("")
+    lines.append("| Hub | Peak |")
+    lines.append("|---|---|")
+    for hub, val in report["hubs"]:
+        lines.append(f"| {hub} | {val} |")
+    lines.append("")
+
+    lines.append("## Week-by-week breakdown (Mon-Sun, local time)")
+    lines.append("")
+    lines.append(f"| Week of | Peak | Avg | Hrs > {T} | Hrs > {T2} |")
+    lines.append("|---|---|---|---|---|")
+    for w in report["weeks"]:
+        lines.append(
+            f"| {w['week']} | {w['peak']} | {w['avg']:.1f}"
+            f" | {w['hrs_t']:.1f}h | {w['hrs_t2']:.1f}h |"
+        )
+    lines.append("")
+
+    lines.append("## Concurrent users by hour of day (local time)")
+    lines.append("")
+    lines.append(f"| Hour | Peak | Avg | % > {T} |")
+    lines.append("|---|---|---|---|")
+    for h in report["hours"]:
+        lines.append(
+            f"| {h['label']} | {h['peak']} | {h['avg']:.1f} | {h['pct']:.1f}% |"
+        )
+    lines.append("")
+
+    lines.append("## Concurrent users by day of week (local time)")
+    lines.append("")
+    lines.append(f"| Day | Peak | Avg | % > {T} |")
+    lines.append("|---|---|---|---|")
+    for dow in report["days_of_week"]:
+        lines.append(
+            f"| {dow['label']} | {dow['peak']} | {dow['avg']:.1f} | {dow['pct']:.1f}% |"
+        )
+
+    return "\n".join(lines)
+
+
+def format_html(report):
+    """Render report data as a self-contained HTML document."""
+    days = report["days"]
+    T = report["threshold"]
+    T2 = report["threshold2"]
+
+    def th(*cells):
+        return "<tr>" + "".join(f"<th>{c}</th>" for c in cells) + "</tr>"
+
+    def td(*cells):
+        return "<tr>" + "".join(f"<td>{c}</td>" for c in cells) + "</tr>"
+
+    parts = []
+    parts.append(
+        f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cal-ICOR Concurrent Users Report</title>
+  <style>
+    body {{ font-family: sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }}
+    h1 {{ font-size: 1.4em; }}
+    h2 {{ font-size: 1.1em; border-bottom: 1px solid #ccc; padding-bottom: 4px; margin-top: 2em; }}
+    p.meta {{ color: #666; font-size: 0.9em; }}
+    table {{ border-collapse: collapse; margin: 1em 0; font-size: 0.9em; }}
+    th, td {{ border: 1px solid #ddd; padding: 4px 12px; }}
+    th {{ background: #f0f0f0; }}
+    td {{ text-align: right; }}
+    td:first-child {{ text-align: left; }}
+    .bar {{ font-family: monospace; color: #999; }}
+  </style>
+</head>
+<body>
+<h1>Cal-ICOR JupyterHub Concurrent User Report</h1>
+<p class="meta">
+  Generated: {report["generated"]} &nbsp;|&nbsp;
+  Range: last {days} days &nbsp;|&nbsp;
+  Threshold: {T} users &nbsp;|&nbsp;
+  UTC offset: {report["tz_offset"]:+d}h
+</p>"""
+    )
+
+    parts.append(f"<h2>Overall statistics (last {days} days)</h2><table>")
+    parts.append(th("Metric", "Value"))
+    parts.append(
+        td("Peak concurrent users", f"<strong>{report['overall']['peak']}</strong>")
+    )
+    for a in report["overall"]["above"]:
+        parts.append(
+            td(
+                f"Fraction of time above {a['n']} users",
+                f"{a['pct']:.2f}% (~{a['hours']:.1f} hours)",
+            )
+        )
+    parts.append("</table>")
+
+    parts.append(f"<h2>Per-hub peak concurrent users (last {days} days)</h2><table>")
+    parts.append(th("Hub", "Peak", "Chart"))
+    for hub, val in report["hubs"]:
+        bar = "#" * (val // 5)
+        parts.append(td(hub, val, f'<span class="bar">{bar}</span>'))
+    parts.append("</table>")
+
+    parts.append("<h2>Week-by-week breakdown (Mon-Sun, local time)</h2><table>")
+    parts.append(th("Week of", "Peak", "Avg", f"Hrs &gt; {T}", f"Hrs &gt; {T2}"))
+    for w in report["weeks"]:
+        parts.append(
+            td(
+                w["week"],
+                w["peak"],
+                f"{w['avg']:.1f}",
+                f"{w['hrs_t']:.1f}h",
+                f"{w['hrs_t2']:.1f}h",
+            )
+        )
+    parts.append("</table>")
+
+    parts.append("<h2>Concurrent users by hour of day (local time)</h2><table>")
+    parts.append(th("Hour", "Peak", "Avg", f"% &gt; {T}"))
+    for h in report["hours"]:
+        parts.append(td(h["label"], h["peak"], f"{h['avg']:.1f}", f"{h['pct']:.1f}%"))
+    parts.append("</table>")
+
+    parts.append("<h2>Concurrent users by day of week (local time)</h2><table>")
+    parts.append(th("Day", "Peak", "Avg", f"% &gt; {T}"))
+    for dow in report["days_of_week"]:
+        parts.append(
+            td(dow["label"], dow["peak"], f"{dow['avg']:.1f}", f"{dow['pct']:.1f}%")
+        )
+    parts.append("</table>")
+
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+def write_report(report, fmt, script_dir):
+    """Write a formatted report to scripts/reports/."""
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    ext = {"text": "txt", "markdown": "md", "html": "html"}[fmt]
+    path = script_dir / "reports" / f"concurrent-users-{date_str}.{ext}"
+
+    formatters = {"text": format_text, "markdown": format_markdown, "html": format_html}
+    path.write_text(formatters[fmt](report), encoding="utf-8")
+    print(f"\nReport written to {path}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -127,6 +383,12 @@ def main():
         default=-7,
         help="Hours offset from UTC for local time display (default: -7 for PDT)",
     )
+    parser.add_argument(
+        "--report-format",
+        choices=["text", "markdown", "html"],
+        default="text",
+        help="Write a report to scripts/reports/ in the specified format (default: text)",
+    )
     args = parser.parse_args()
 
     window = f"{args.days}d"
@@ -137,6 +399,19 @@ def main():
 
     print(f"Querying {args.url} over the last {args.days} days")
     print(f"Threshold: {T} users  |  UTC offset: {args.tz_offset:+d}h\n")
+
+    report = {
+        "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        "days": args.days,
+        "threshold": T,
+        "threshold2": T2,
+        "tz_offset": args.tz_offset,
+        "overall": {"peak": None, "above": []},
+        "hubs": [],
+        "weeks": [],
+        "hours": [],
+        "days_of_week": [],
+    }
 
     # -------------------------------------------------------------------------
     # Section 1: Overall peak + time-above-threshold
@@ -149,6 +424,7 @@ def main():
     )
     peak = int(data["data"]["result"][0]["value"][1])
     print(f"  Peak concurrent users (all hubs): {peak}")
+    report["overall"]["peak"] = peak
 
     for n in [T, T2]:
         data = query(
@@ -161,6 +437,9 @@ def main():
         print(
             f"  Fraction of time above {n:>3} users: "
             f"{frac * 100:5.2f}%  (~{hours_above:.1f} hours total)"
+        )
+        report["overall"]["above"].append(
+            {"n": n, "pct": frac * 100, "hours": hours_above}
         )
 
     # -------------------------------------------------------------------------
@@ -185,6 +464,7 @@ def main():
             continue
         bar = "#" * (val // 5)
         print(f"  {hub:<28} {val:>5}  {bar}")
+        report["hubs"].append((hub, val))
 
     # -------------------------------------------------------------------------
     # Fetch range data once for the remaining analyses (30m resolution)
@@ -218,6 +498,9 @@ def main():
             f"  {week:<12} {wpeak:>5}  {wavg:>5.1f}  "
             f"{hrs_t:>6.1f}h  {hrs_t2:>7.1f}h  {bar}"
         )
+        report["weeks"].append(
+            {"week": week, "peak": wpeak, "avg": wavg, "hrs_t": hrs_t, "hrs_t2": hrs_t2}
+        )
 
     # -------------------------------------------------------------------------
     # Section 4: Hour-of-day breakdown
@@ -240,6 +523,7 @@ def main():
         bar = "#" * (hpeak // 5)
         label = f"{h:02d}:00-{h + 1:02d}:00"
         print(f"  {label:<10} {hpeak:>5}  {havg:>5.1f}  {pct:>7.1f}%  {bar}")
+        report["hours"].append({"label": label, "peak": hpeak, "avg": havg, "pct": pct})
 
     # -------------------------------------------------------------------------
     # Section 5: Day-of-week breakdown
@@ -261,6 +545,14 @@ def main():
         pct = sum(1 for v in s if v > T) / len(s) * 100
         bar = "#" * (dpeak // 5)
         print(f"  {DAYS_OF_WEEK[d]:<5} {dpeak:>5}  {davg:>5.1f}  {pct:>7.1f}%  {bar}")
+        report["days_of_week"].append(
+            {"label": DAYS_OF_WEEK[d], "peak": dpeak, "avg": davg, "pct": pct}
+        )
+
+    # -------------------------------------------------------------------------
+    # Optional: write report to scripts/reports/
+    # -------------------------------------------------------------------------
+    write_report(report, args.report_format, Path(__file__).parent)
 
 
 if __name__ == "__main__":

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -5,6 +5,10 @@ Query Prometheus for concurrent JupyterHub user statistics across all prod hubs.
 Requires an active port-forward to the Prometheus server:
     kubectl -n support port-forward deployment/support-prometheus-server 9090
 
+kubectl will print "Handling connection for 9090" to stderr for each request.
+To suppress it, redirect stderr when starting the port-forward:
+    kubectl -n support port-forward deployment/support-prometheus-server 9090 2>/dev/null &
+
 Then run:
     python3 scripts/query_concurrent_users.py
 
@@ -19,6 +23,7 @@ Optional arguments:
     --save-report         Optionally save a report to scripts/reports/: text, markdown (or md), or html
     --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
                           explicit CLI args always win.
+    --debug               Print each Prometheus query and sample counts as the script runs.
 
 Example config file (my-deployment.yaml):
     namespace_pattern: ".*-staging"
@@ -409,6 +414,8 @@ def main(args):
     # -------------------------------------------------------------------------
     section(f"Overall statistics (last {args.days} days)")
 
+    if args.debug:
+        print("  [debug] querying overall peak concurrent users")
     data = query(
         args.url,
         f"max_over_time(sum(jupyterhub_running_servers{{{ns_filter}}}){subquery})",
@@ -418,6 +425,8 @@ def main(args):
     report["overall"]["peak"] = peak
 
     for n in [T, T2]:
+        if args.debug:
+            print(f"  [debug] querying % of time above {n} users")
         data = query(
             args.url,
             f"sum_over_time((sum(jupyterhub_running_servers{{{ns_filter}}}) > bool {n}){subquery})"
@@ -438,6 +447,8 @@ def main(args):
     # -------------------------------------------------------------------------
     section(f"Per-namespace peak concurrent users (last {args.days} days)")
 
+    if args.debug:
+        print("  [debug] querying per-namespace peak concurrent users")
     data = query(
         args.url, f"max_over_time(jupyterhub_running_servers{{{ns_filter}}}{subquery})"
     )
@@ -460,9 +471,13 @@ def main(args):
     # -------------------------------------------------------------------------
     # Fetch range data once for the remaining analyses (30m resolution)
     # -------------------------------------------------------------------------
+    if args.debug:
+        print(f"\n  [debug] fetching {args.days}d of range samples at 30m resolution")
     samples = get_range_samples(
         args.url, args.days, args.timezone, args.namespace_pattern
     )
+    if args.debug:
+        print(f"  [debug] got {len(samples)} samples")
 
     # -------------------------------------------------------------------------
     # Section 3: Week-by-week breakdown
@@ -470,6 +485,10 @@ def main(args):
     section("Week-by-week breakdown (Mon–Sun, local time)")
 
     # Fetch weekly active users: last sample per week gives WAU for that week
+    if args.debug:
+        print(
+            "  [debug] fetching weekly active users (jupyterhub_active_users{period='7d'})"
+        )
     _end_ts = int(time.time())
     _start_ts = _end_ts - args.days * 86400
     _tz = ZoneInfo(args.timezone)
@@ -485,6 +504,8 @@ def main(args):
         _dt = datetime.fromtimestamp(int(_ts), tz=_tz)
         _wk = (_dt - timedelta(days=_dt.weekday())).strftime("%Y-%m-%d")
         week_active_users[_wk] = int(float(_val))
+    if args.debug:
+        print(f"  [debug] got WAU data for {len(week_active_users)} weeks")
 
     week_samples = defaultdict(list)
     for dt, v in samples:
@@ -632,6 +653,12 @@ if __name__ == "__main__":
         "--save-report",
         choices=["text", "markdown", "md", "html"],
         help="Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Print each Prometheus query and sample counts as the script runs",
     )
 
     if config_defaults:

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -130,6 +130,16 @@ def format_text(report):
         f"Range: last {days} days  |  Thresholds: {T}, {T2} users per node"
         f"  |  Namespace: {report['namespace_pattern']}  |  Timezone: {report['timezone']}"
     )
+    lines.append(
+        f"\nColumn legend:\n"
+        f"  Peak     highest concurrent users observed\n"
+        f"  Active   unique users with a running server (7-day rolling window)\n"
+        f"  Hrs>{T}  hours where concurrent users exceeded {T} (node capacity)\n"
+        f"  Hrs>{T2}  hours where concurrent users exceeded {T2} (1.5x node capacity)\n"
+        f"  Avg      average concurrent users in the time bucket\n"
+        f"  Pct>{T}  % of samples where concurrent users exceeded {T}\n"
+        f"  Chart    bar chart; each # = 5 users"
+    )
 
     lines.append(f"\n{'=' * 60}")
     lines.append(f"  Overall statistics (last {days} days)")
@@ -191,6 +201,7 @@ def format_text(report):
             f"  {dow['label']:<5} {dow['peak']:>5}  {dow['avg']:>5.1f}"
             f"  {dow['pct']:>7.1f}%  {bar}"
         )
+    lines.append("")
 
     return "\n".join(lines)
 
@@ -211,6 +222,24 @@ def format_markdown(report):
         f"**Namespace:** {report['namespace_pattern']}  |  "
         f"**Timezone:** {report['timezone']}"
     )
+    lines.append("")
+    lines.append("**Column legend:**")
+    lines.append("")
+    lines.append("| Column | Description |")
+    lines.append("|---|---|")
+    lines.append("| Peak | Highest concurrent users observed |")
+    lines.append(
+        "| Active | Unique users with a running server (7-day rolling window) |"
+    )
+    lines.append(
+        f"| Hrs>{T} | Hours where concurrent users exceeded {T} (node capacity) |"
+    )
+    lines.append(
+        f"| Hrs>{T2} | Hours where concurrent users exceeded {T2} (1.5x node capacity) |"
+    )
+    lines.append("| Avg | Average concurrent users in the time bucket |")
+    lines.append(f"| Pct>{T} | % of samples where concurrent users exceeded {T} |")
+    lines.append("| Chart | Bar chart; each # = 5 users |")
     lines.append("")
 
     lines.append(f"## Overall statistics (last {days} days)")
@@ -309,6 +338,19 @@ def format_html(report):
 </p>"""
     )
 
+    parts.append(
+        f"<h2>Column legend</h2><table>"
+        f"{th('Column', 'Description')}"
+        f"{td('Peak', 'Highest concurrent users observed')}"
+        f"{td('Active', 'Unique users with a running server (7-day rolling window)')}"
+        f"{td(f'Hrs&gt;{T}', f'Hours where concurrent users exceeded {T} (node capacity)')}"
+        f"{td(f'Hrs&gt;{T2}', f'Hours where concurrent users exceeded {T2} (1.5x node capacity)')}"
+        f"{td('Avg', 'Average concurrent users in the time bucket')}"
+        f"{td(f'Pct&gt;{T}', f'% of samples where concurrent users exceeded {T}')}"
+        f"{td('Chart', 'Bar chart; each # = 5 users')}"
+        f"</table>"
+    )
+
     parts.append(f"<h2>Overall statistics (last {days} days)</h2><table>")
     parts.append(th("Metric", "Value"))
     parts.append(
@@ -385,12 +427,22 @@ def main(args):
     subquery = f"[{window}:{args.step}]"
     ns_filter = f'namespace=~"{args.namespace_pattern}"'
     T = args.threshold
-    T2 = T + 40
+    T2 = int(T * 1.5)
 
     print(f"Querying {args.url} over the last {args.days} days")
     print(
         f"Thresholds: {T}, {T2} users per node  |  "
-        f"Namespace: {args.namespace_pattern}  |  Timezone: {args.timezone}\n"
+        f"Namespace: {args.namespace_pattern}  |  Timezone: {args.timezone}"
+    )
+    print(
+        f"\nColumn legend:\n"
+        f"  Peak     highest concurrent users observed\n"
+        f"  Active   unique users with a running server (7-day rolling window)\n"
+        f"  Hrs>{T}  hours where concurrent users exceeded {T} (node capacity)\n"
+        f"  Hrs>{T2}  hours where concurrent users exceeded {T2} (1.5x node capacity)\n"
+        f"  Avg      average concurrent users in the time bucket\n"
+        f"  Pct>{T}  % of samples where concurrent users exceeded {T}\n"
+        f"  Chart    bar chart; each # = 5 users"
     )
 
     report = {

--- a/scripts/query_concurrent_users.py
+++ b/scripts/query_concurrent_users.py
@@ -9,13 +9,21 @@ Then run:
     python3 scripts/query_concurrent_users.py
 
 Optional arguments:
-    --days           Number of days to look back (default: 90)
-    --step           Query resolution step for instant queries (default: 5m)
-    --url            Prometheus URL (default: http://localhost:9090)
-    --threshold      User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
-    --timezone       IANA timezone for local time display, should match hub users' location
-                     (default: America/Los_Angeles)
-    --save-report    Optionally save a report to scripts/reports/: text, markdown (or md), or html
+    --days                Number of days to look back (default: 90)
+    --step                Query resolution step for instant queries (default: 5m)
+    --url                 Prometheus URL (default: http://localhost:9090)
+    --threshold           User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
+    --timezone            IANA timezone for local time display, should match hub users' location
+                          (default: America/Los_Angeles)
+    --namespace-pattern   Prometheus regex to match hub namespaces (default: .*-prod)
+    --save-report         Optionally save a report to scripts/reports/: text, markdown (or md), or html
+    --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
+                          explicit CLI args always win. Requires ruamel.yaml (pip install ruamel.yaml).
+
+Example config file (my-deployment.yaml):
+    namespace_pattern: ".*-staging"
+    timezone: "America/New_York"
+    threshold: 60
 """
 
 import argparse
@@ -30,6 +38,8 @@ from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import urlopen
 from zoneinfo import ZoneInfo
+
+from ruamel.yaml import YAML
 
 DAYS_OF_WEEK = list(calendar.day_abbr)
 
@@ -70,7 +80,7 @@ def query_range(url, promql, start, end, step):
     return data["data"]["result"][0]["values"]
 
 
-def get_range_samples(url, days, tz_name):
+def get_range_samples(url, days, tz_name, namespace_pattern):
     """
     Fetch total running servers at 30m resolution over the given number of days.
     Returns a list of (datetime_local, value) tuples, converted to tz_name.
@@ -79,10 +89,10 @@ def get_range_samples(url, days, tz_name):
     start = end - days * 86400
     tz = ZoneInfo(tz_name)
 
-    # 148 days at 30m = ~7104 samples, well within the 11000-point limit
+    # 90 days at 30m = ~4320 samples, well within the 11000-point limit
     values = query_range(
         url,
-        'sum(jupyterhub_running_servers{namespace=~".*-prod"})',
+        f'sum(jupyterhub_running_servers{{namespace=~"{namespace_pattern}"}})',
         start,
         end,
         step=1800,
@@ -364,7 +374,7 @@ def write_report(report, fmt, script_dir):
 def main(args):
     window = f"{args.days}d"
     subquery = f"[{window}:{args.step}]"
-    ns_filter = 'namespace=~".*-prod"'
+    ns_filter = f'namespace=~"{args.namespace_pattern}"'
     T = args.threshold
     T2 = T + 40
 
@@ -442,7 +452,9 @@ def main(args):
     # -------------------------------------------------------------------------
     # Fetch range data once for the remaining analyses (30m resolution)
     # -------------------------------------------------------------------------
-    samples = get_range_samples(args.url, args.days, args.timezone)
+    samples = get_range_samples(
+        args.url, args.days, args.timezone, args.namespace_pattern
+    )
 
     # -------------------------------------------------------------------------
     # Section 3: Week-by-week breakdown
@@ -530,8 +542,23 @@ def main(args):
 
 
 if __name__ == "__main__":
+    # Pre-parse to get --config before setting up the full parser, so config
+    # file values can be applied as defaults before argparse sees the rest.
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("-c", "--config")
+    pre_args, _ = pre.parse_known_args()
+
+    config_defaults = {}
+    if pre_args.config:
+        _yaml = YAML(typ="safe")
+        with open(pre_args.config) as f:
+            config_defaults = _yaml.load(f) or {}
+
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "-c", "--config", metavar="FILE", help="Path to a YAML config file"
     )
     parser.add_argument(
         "-d", "--days", type=int, default=90, help="Days to look back (default: 90)"
@@ -561,9 +588,19 @@ if __name__ == "__main__":
         help="IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)",
     )
     parser.add_argument(
+        "-n",
+        "--namespace-pattern",
+        default=".*-prod",
+        help="Prometheus regex to match hub namespaces (default: .*-prod)",
+    )
+    parser.add_argument(
         "-r",
         "--save-report",
         choices=["text", "markdown", "md", "html"],
         help="Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)",
     )
+
+    if config_defaults:
+        parser.set_defaults(**config_defaults)
+
     main(parser.parse_args())

--- a/scripts/reports/.gitignore
+++ b/scripts/reports/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all generated reports; keep this file.
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Adds `scripts/query_concurrent_users.py`, a utility for querying Prometheus for concurrent JupyterHub user statistics across all prod hubs. Also adds `scripts/reports/` (gitignored) as a home for generated report files.

### What it reports

- Overall peak concurrent users and fraction of time above configurable thresholds
- Per-hub peak breakdown with ASCII chart
- Week-by-week breakdown (Mon–Sun)
- Hour-of-day and day-of-week patterns
- All output in the configured timezone (default: America/Los_Angeles)

### Designed for reuse

The script is not cal-icor specific. Key defaults can be overridden via CLI args or a YAML config file (`--config`), making it usable by other JupyterHub deployments:

```yaml
# my-deployment.yaml
namespace_pattern: ".*-staging"
timezone: "America/New_York"
threshold: 60
```

### Usage

Requires an active port-forward to the Prometheus server:
```
kubectl -n support port-forward deployment/support-prometheus-server 9090 2>/dev/null &
```

Then run:
```
python3 scripts/query_concurrent_users.py
```

Output from `--help`:

```
$ ./query_concurrent_users.py --help
usage: query_concurrent_users.py [-h] [-c FILE] [-d DAYS] [--start DATETIME] [--end DATETIME] [--step STEP] [-u URL] [-t THRESHOLD] [-z TIMEZONE] [-n NAMESPACE_PATTERN]
                                 [-r {text,markdown,md,html}] [--debug]

Query Prometheus for concurrent JupyterHub user statistics across all prod hubs.

Requires an active port-forward to the Prometheus server:
    kubectl -n support port-forward deployment/support-prometheus-server 9090

kubectl will print "Handling connection for 9090" to stdout for each request.
To suppress it, redirect both stdout and stderr when starting the port-forward:
    kubectl -n support port-forward deployment/support-prometheus-server 9090 >/dev/null 2>&1 &

Then run:
    python3 scripts/query_concurrent_users.py

Optional arguments:
    --days                Number of days to look back (default: 90). Mutually exclusive
                          with --start/--end.
    --start               Start of the query window in local time, e.g. "2026-03-01" or
                          "2026-03-01 08:00". Requires --end. Mutually exclusive with --days.
    --end                 End of the query window in local time, e.g. "2026-04-15" or
                          "2026-04-15 18:00". Requires --start. Mutually exclusive with --days.
    --step                Sub-query resolution for instant queries (peak, % above threshold).
                          In Prometheus subquery notation [90d:5m], this is the '5m': how
                          finely Prometheus resamples the inner expression across the lookback
                          window. Does not affect the time-series data returned for the
                          hourly/daily/weekly breakdown tables. (default: 5m)
    --url                 Prometheus URL (default: http://localhost:9090)
    --threshold           User count threshold for "above N users" stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can support.
    --timezone            IANA timezone for local time display, should match hub users' location
                          (default: America/Los_Angeles)
    --namespace-pattern   Prometheus regex to match hub namespaces (default: .*-prod)
    --save-report         Optionally save a report to scripts/reports/: text, markdown (or md), or html
    --config              Path to a YAML config file. Any key matching a CLI arg sets its default;
                          explicit CLI args always win.
    --debug               Print each Prometheus query and sample counts as the script runs.

Two independent resolutions are used per run:

  1. Instant query sub-query resolution (--step, default 5m)
     Controls how finely the peak/threshold instant queries sample across the lookback
     window. Returns a single aggregated value, not a time series.

  2. Range data sample interval (not user-configurable)
     Controls how many data points are fetched for the hourly, daily, and week-by-week
     breakdown tables. Auto-scales with the query window to maximise detail while staying
     within Prometheus point limits (~11k points):
         ≤  7 days  →  5-minute sample interval  (~2,000 points) — single-week deep-dives
         ≤ 30 days  → 15-minute sample interval  (~2,900 points) — month-long snapshots
         ≤ 90 days  → 30-minute sample interval  (~4,300 points) — default rolling view
         > 90 days  → 60-minute sample interval  (~4,300 points) — semester-plus ranges

Note: --start/--end ranges shorter than 7 days suppress the Active (WAU) column in
the week-by-week table. jupyterhub_active_users always reflects a rolling 7-day window,
so its values would extend outside the query range and be misleading for short spans.

Examples:
    # Default: last 90 days, 30-minute sample interval for breakdown tables
    python3 scripts/query_concurrent_users.py

    # Last 30 days, 15-minute sample interval
    python3 scripts/query_concurrent_users.py -d 30

    # Full spring semester — 115-day span, 60-minute sample interval
    python3 scripts/query_concurrent_users.py \
        --start "2026-01-20" --end "2026-05-15" -r html

    # Historical month snapshot — 30-day span, 15-minute sample interval
    python3 scripts/query_concurrent_users.py \
        --start "2026-02-01" --end "2026-03-01"

    # Midterm week deep-dive — 5-day span, 5-minute sample interval for maximum granularity
    python3 scripts/query_concurrent_users.py \
        --start "2026-03-09 00:00" --end "2026-03-13 23:59"

Example config file (my-deployment.yaml):
    namespace_pattern: ".*-staging"
    timezone: "America/New_York"
    threshold: 60

options:
  -h, --help            show this help message and exit
  -c FILE, --config FILE
                        Path to a YAML config file
  -d DAYS, --days DAYS  Days to look back (default: 90). Mutually exclusive with --start/--end.
  --start DATETIME      Start of query window in local timezone, e.g. "2026-03-01" or "2026-03-01 08:00". Requires --end. Mutually exclusive with --days.
  --end DATETIME        End of query window in local timezone, e.g. "2026-04-15" or "2026-04-15 18:00". Requires --start. Mutually exclusive with --days.
  --step STEP           Query resolution step for instant queries (default: 5m)
  -u URL, --url URL     Prometheus URL (default: http://localhost:9090)
  -t THRESHOLD, --threshold THRESHOLD
                        User count threshold for percentage/hours stats (default: 80). This is roughly the total users that a single node with ~64GB total ram can
                        support.
  -z TIMEZONE, --timezone TIMEZONE
                        IANA timezone for local time display, should match hub users' location (default: America/Los_Angeles)
  -n NAMESPACE_PATTERN, --namespace-pattern NAMESPACE_PATTERN
                        Prometheus regex to match hub namespaces (default: .*-prod)
  -r {text,markdown,md,html}, --save-report {text,markdown,md,html}
                        Save a report to scripts/reports/ in the specified format (md and markdown are equivalent)
  --debug               Print each Prometheus query and sample counts as the script runs
```

Generated with [Claude Code](https://claude.com/claude-code) with some help from @shaneknapp ;)