### PR TITLE
parallelize hub deployments via matrix build

### DIFF
--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -1,6 +1,11 @@
 # This workflow will determine if the base hub image and/or single-user server
 # image for any or all hubs has has changed, and if so, deploy accordingly.
 #
+# Deployments are parallelized via a matrix build. A lightweight "determine"
+# job resolves the hub list and outputs it as a JSON array; the deploy job
+# fans out one runner per hub with fail-fast disabled so a single failure does
+# not cancel the remaining deployments.
+#
 name: Deploy staging and prod hubs
 permissions:
   contents: read
@@ -13,9 +18,14 @@ on:
       - prod
 
 jobs:
-  deploy-hubs-to-staging:
+  # ---------------------------------------------------------------------------
+  # Staging
+  # ---------------------------------------------------------------------------
+  determine-staging-hubs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
+    outputs:
+      hubs: ${{ steps.set-hubs.outputs.hubs }}
     steps:
       - name: Get PR labels
         id: pr-labels
@@ -26,15 +36,8 @@ jobs:
       - name: Check for hubs that need deploying from the labels on the merge commit to staging
         run: |
           echo "PR labels: ${{ steps.pr-labels.outputs.labels }}"
-          # If the PR labels "hub-images" or "jupyterhub-deployment" are
-          # present, this means the base hub image has changed, and all hubs
-          # (staging or prod) need to be redeployed.
-          #
           if [[ -n ${GITHUB_PR_LABEL_HUB_IMAGES} || -n ${GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT} ]]; then
             echo "DEPLOY=1" >> "$GITHUB_ENV"
-          # Otherwise, check to see if the PR labels contain any hubs, and 
-          # deploy just those hubs to staging.
-          #
           else
             for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
               if [[ "$label" == hub-* ]]; then
@@ -47,7 +50,7 @@ jobs:
         if: ${{ env.DEPLOY }}
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 1
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
@@ -55,14 +58,43 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Determine hubs to deploy
+        id: set-hubs
+        run: |
+          if [[ -z "$DEPLOY" ]]; then
+            echo "hubs=[]" >> "$GITHUB_OUTPUT"
+          else
+            hubs=$(python .github/scripts/determine-hub-deployments.py \
+                     --ignore gpu-demo rstudio \
+                   | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "hubs=${hubs}" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-hubs-to-staging:
+    needs: determine-staging-hubs
+    if: needs.determine-staging-hubs.outputs.hubs != '[]'
+    strategy:
+      matrix:
+        hub: ${{ fromJson(needs.determine-staging-hubs.outputs.hubs) }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the image repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       - name: Install dependencies
-        if: ${{ env.DEPLOY }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Install SOPS
-        if: ${{ env.DEPLOY }}
         run: |
           mkdir -p "${HOME}/bin"
           curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
@@ -70,30 +102,29 @@ jobs:
           echo "${HOME}/bin" >> "$GITHUB_PATH"
 
       - name: Auth to gcloud
-        if: ${{ env.DEPLOY }}
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GKE_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
-        if: ${{ env.DEPLOY }}
         uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: 'gke-gcloud-auth-plugin'
 
-      - name: Deploy hubs to staging
-        if: ${{ env.DEPLOY }}
+      - name: Deploy ${{ matrix.hub }} to staging
         run: |
-          while read -r deployment; do
-            echo "Deploying single-user image and hub config to ${deployment}"
-            hubploy --verbose deploy --timeout 30m "${deployment}" hub staging
-            echo
-          done < <(python .github/scripts/determine-hub-deployments.py --ignore gpu-demo rstudio)
+          echo "Deploying ${{ matrix.hub }} to staging"
+          hubploy --verbose deploy --timeout 30m "${{ matrix.hub }}" hub staging
 
-  deploy-hubs-to-prod:
+  # ---------------------------------------------------------------------------
+  # Prod
+  # ---------------------------------------------------------------------------
+  determine-prod-hubs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
     runs-on: ubuntu-latest
+    outputs:
+      hubs: ${{ steps.set-hubs.outputs.hubs }}
     steps:
       - name: Get PR labels
         id: pr-labels
@@ -104,15 +135,8 @@ jobs:
       - name: Check for hubs that need deploying from the labels on the merge commit to prod
         run: |
           echo "PR labels: ${{ steps.pr-labels.outputs.labels }}"
-          # If the PR labels "hub-images" or "jupyterhub-deployment" are
-          # present, this means the base hub image has changed, and all hubs
-          # (staging or prod) need to be redeployed.
-          #
           if [[ -n ${GITHUB_PR_LABEL_HUB_IMAGES} || -n ${GITHUB_PR_LABEL_JUPYTERHUB_DEPLOYMENT} ]]; then
             echo "DEPLOY=1" >> "$GITHUB_ENV"
-          # Otherwise, check to see if the PR labels contain any hubs, and 
-          # deploy just those hubs to prod.
-          #
           else
             for label in $(echo -e "${{ steps.pr-labels.outputs.labels }}"); do
               if [[ "$label" == hub-* ]]; then
@@ -125,7 +149,7 @@ jobs:
         if: ${{ env.DEPLOY }}
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 1
 
       - name: Setup python
         if: ${{ env.DEPLOY }}
@@ -133,14 +157,43 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Determine hubs to deploy
+        id: set-hubs
+        run: |
+          if [[ -z "$DEPLOY" ]]; then
+            echo "hubs=[]" >> "$GITHUB_OUTPUT"
+          else
+            hubs=$(python .github/scripts/determine-hub-deployments.py \
+                     --ignore gpu-demo rstudio \
+                   | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "hubs=${hubs}" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-hubs-to-prod:
+    needs: determine-prod-hubs
+    if: needs.determine-prod-hubs.outputs.hubs != '[]'
+    strategy:
+      matrix:
+        hub: ${{ fromJson(needs.determine-prod-hubs.outputs.hubs) }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the image repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       - name: Install dependencies
-        if: ${{ env.DEPLOY }}
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Install SOPS
-        if: ${{ env.DEPLOY }}
         run: |
           mkdir -p "${HOME}/bin"
           curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
@@ -148,23 +201,17 @@ jobs:
           echo "${HOME}/bin" >> "$GITHUB_PATH"
 
       - name: Auth to gcloud
-        if: ${{ env.DEPLOY }}
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GKE_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install Google Cloud SDK
-        if: ${{ env.DEPLOY }}
         uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: 'gke-gcloud-auth-plugin'
 
-      - name: Deploy hubs to prod
-        if: ${{ env.DEPLOY }}
+      - name: Deploy ${{ matrix.hub }} to prod
         run: |
-          while read -r deployment; do
-            echo "Deploying single-user image and hub config to ${deployment}"
-            hubploy --verbose deploy --timeout 30m "${deployment}" hub prod
-            echo
-          done < <(python .github/scripts/determine-hub-deployments.py --ignore gpu-demo rstudio)
+          echo "Deploying ${{ matrix.hub }} to prod"
+          hubploy --verbose deploy --timeout 30m "${{ matrix.hub }}" hub prod


### PR DESCRIPTION
Replaces the serial while-read hubploy loop with a two-job matrix pattern for both staging and prod.

## How it works

A lightweight `determine` job resolves the hub list from PR labels and outputs it as a JSON array. A `deploy` job then fans out one runner per hub using `strategy.matrix`, with `fail-fast: false` so a single hub failure does not cancel the rest.

## Changes

- `determine-staging-hubs` / `determine-prod-hubs`: run label check, checkout, and `determine-hub-deployments.py`; output hub list as JSON array via `jq`
- `deploy-hubs-to-staging` / `deploy-hubs-to-prod`: matrix job, one runner per hub, each with full setup + single hubploy call
- `fail-fast: false` on both matrix jobs

## Trade-offs

Each matrix job repeats the ~2-3 min setup (checkout, Python, SOPS, gcloud auth). This is worth it: wall time drops from `N x deploy_time` to `setup_time + max(deploy_time)`, and each hub gets its own job log and pass/fail status in the GitHub UI.

Generated with Claude Code