### PR TITLE
[CCC] Revert Tag to 6d61d3c15d47

### DIFF
--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -76,7 +76,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
-      tag: f15facc4e0c2
+      tag: 6d61d3c15d47
     extraFiles:
       # DH-216
       remove-exporters:

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -51,7 +51,7 @@ jupyterhub:
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
-      tag: f15facc4e0c2
+      tag: 6d61d3c15d47
     extraFiles:
       # DH-216
       remove-exporters:


### PR DESCRIPTION
- The new tag upgraded to python 3.12 and was breaking tests in the Data 8 notebooks