### PR TITLE
Fix logo image syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cal-ICOR JupyterHubs
 
-![Cal-ICOR Logo](https://www.cal-icor.org/images/logos/cal-icor.png =250x250)
+<img src="https://www.cal-icor.org/images/logos/cal-icor.png" width="250" height="250">
 
 Contains a fully reproducible configuration for JupyterHub for the Cal ICOR deployments.
 


### PR DESCRIPTION
Updated logo syntax in README.md for proper rendering.