### PR TITLE
bump to latest placeholder chart

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: node-placeholder-scaler
-    version: 0.0.1-0.dev.git.1.h3d7ed14
+    version: 0.0.1-0.dev.git.416.h6d6cc72
     repository: oci://us-central1-docker.pkg.dev/cal-icor-hubs/helm-charts
   - name: prometheus-statsd-exporter
     version: 0.11.0

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -193,6 +193,9 @@ node-placeholder-scaler:
   calendarTimezone: "America/Los_Angeles"
   calendarOverrideEnabled: True
 
+  nodeSelector:
+    hub.jupyter.org/pool-name: support-pool-2026-02-12
+
   # cpuThreshold: 0.25 # ignore this as our workloads are memory-bound, not cpu
   memoryThreshold: 0.40 # set this pretty high to avoid overloading nodes and get new ones spun up earlier
   scalingStrategy: "mem" # Options: cpu, mem, balanced (default)


### PR DESCRIPTION
this is to test the latest changes specified in here: https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/pull/28