### PR TITLE
give all workshop users a minimum of 2G ram

### DIFF
--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -74,5 +74,5 @@ jupyterhub:
         pvcName: home-nfs
         subPath: "{username}"
     memory:
-      guarantee: 1G
+      guarantee: 2G
       limit: 2G


### PR DESCRIPTION
while i'm not seeing much in the way of memory starvation on the single node that is currently in use for a workshop, i'm (mildly) concerned that this could be an issue.  to head this off at the pass, i suggest we set the guarantee and limit to 2G for all workshop users.

here's the current memory usage for the hub:

<img width="777" height="571" alt="image" src="https://github.com/user-attachments/assets/4f8a1167-1de7-43ea-b6c2-cffdc1109e82" />

since all users are currently on one node, it doesn't have much headroom:

```
Node gke-spring-2025-user-base-fd0b35e6-9f9t has 0.66 CPU free ratio and 0.19 Memory free ratio.
```

the main issue here is that for current users will need to log out and back in again to have this change be applied to their session.