### PR TITLE
bumping the node placeholder chart version to continue testing

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: node-placeholder-scaler
-    version: 0.0.1-0.dev.git.416.h6d6cc72
+    version: 0.0.1-0.dev.git.419.h34ae431
     repository: oci://us-central1-docker.pkg.dev/cal-icor-hubs/helm-charts
   - name: prometheus-statsd-exporter
     version: 0.11.0


### PR DESCRIPTION
continued testing of https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/pull/28