### PR TITLE
increase the home dirsize reporting frequency to daily

### DIFF
--- a/hub/templates/home-dirsize-reporter.yaml
+++ b/hub/templates/home-dirsize-reporter.yaml
@@ -54,7 +54,7 @@ spec:
             - dirsize-exporter
             - /shared-volume
             - "100" # Use only 100 io operations per second at most
-            - "4320" # Wait 3 days between runs
+            - "1440" # Wait 1 day between runs
             - --port=8000
           ports:
             - containerPort: 8000


### PR DESCRIPTION
since we don't have a lot of storage, we should run the `home-dirsize-reporter` process daily.