### PR TITLE
merging 809 to prod

### DIFF
--- a/hub/templates/home-dirsize-reporter.yaml
+++ b/hub/templates/home-dirsize-reporter.yaml
@@ -54,7 +54,7 @@ spec:
             - dirsize-exporter
             - /shared-volume
             - "100" # Use only 100 io operations per second at most
-            - "1440" # Wait 1 day between runs
+            - "2880" # Wait 2 days between runs
             - --port=8000
           ports:
             - containerPort: 8000


### PR DESCRIPTION
the `home-dirsize-reporter` can take a while to run, and we really don't need the granularity of a daily run. i'll move this to every 2 days for now, and we can fine tune/adjust later if necessary.