### PR TITLE
merge #816 to prod

### DIFF
--- a/deployments/dvc/config/prod.yaml
+++ b/deployments/dvc/config/prod.yaml
@@ -3,6 +3,10 @@ nfsPVC:
     shareName: dvc/prod
 
 jupyterhub:
+  singleuser:
+    image:
+      name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
+      tag: 6d61d3c15d47
   ingress:
     enabled: true
     hosts:

--- a/deployments/folsomlake/config/prod.yaml
+++ b/deployments/folsomlake/config/prod.yaml
@@ -3,6 +3,10 @@ nfsPVC:
     shareName: folsomlake/prod
 
 jupyterhub:
+  singleuser:
+    image:
+      name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
+      tag: 6d61d3c15d47
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
this pins the dvc and folsomlake image deployments to `6d61d3c15d47` in `prod.yaml`.  regardless of what else we deploy to any hubs using `base-user-image`, it won't override these tags.