### PR TITLE
allow user override of opencode config

### DIFF
--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -65,7 +65,8 @@ jupyterhub:
           c.QtPNGExporter.enabled = False
           c.WebPDFExporter.enabled = False
       opencode:
-        mountPath: /etc/opencode/opencode.json
+        # don't use highest-priority 'managed' path: /etc/opencode/opencode.json
+        mountPath: /etc/opencode-default/opencode.json
         data:
           $schema: "https://opencode.ai/config.json"
           model: nrp/qwen3
@@ -110,6 +111,7 @@ jupyterhub:
     extraEnv:
       # Unset NotebookApp from hub/values. Necessary for recent lab versions.
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
+      OPENCODE_CONFIG: /etc/opencode-default/opencode.json
     nodeSelector:
       hub.jupyter.org/pool-name: base-pool
     storage:


### PR DESCRIPTION
rather than using highest-priority [managed settings](https://opencode.ai/docs/config/#managed-settings) path of `/etc/opencode`. Unfortunately, there does not appear to be a way to define config at a lower priority than `~/.config/opencode`, but at least this is below env and project config, making it easier for users to try things.

cc @sean-morris 