### PR TITLE
use locals for project/region, so that we don't need to duplicate these variables in every module

### DIFF
--- a/tofu/root.hcl
+++ b/tofu/root.hcl
@@ -16,6 +16,13 @@
 # Per-unit specifics (cluster name, node zone, labels, module source) live in the
 # unit's own terragrunt.hcl.
 
+# Project and region appear once here and feed both the generated provider below
+# and each unit's inputs, so the literals are never repeated per module.
+locals {
+  project = "cal-icor-hubs"
+  region  = "us-central1"
+}
+
 # Keep the provider lock file with the module code (modules/<name>/) instead of
 # letting Terragrunt copy a duplicate into every unit. Units that source the same
 # module then share one pinned set of provider versions rather than drifting into
@@ -39,7 +46,41 @@ remote_state {
   }
 }
 
+# Provider and version-constraint boilerplate, generated into each unit's working
+# directory so modules don't hand-copy identical files. A module needing custom
+# provider config (modules/network sets default_labels = { hub = "networking" })
+# commits its own provider.tf; if_exists = "skip" leaves that file untouched and
+# only generates one where the module ships none. New leaf modules (e.g. node
+# pools) therefore carry no provider.tf / versions.tf at all.
+generate "versions" {
+  path      = "versions.tf"
+  if_exists = "skip"
+  contents  = <<-EOF
+    terraform {
+      required_version = ">= 1.7"
+
+      required_providers {
+        google = {
+          source  = "hashicorp/google"
+          version = "~> 6.0"
+        }
+      }
+    }
+  EOF
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "skip"
+  contents  = <<-EOF
+    provider "google" {
+      project = "${local.project}"
+      region  = "${local.region}"
+    }
+  EOF
+}
+
 inputs = {
-  project = "cal-icor-hubs"
-  region  = "us-central1"
+  project = local.project
+  region  = local.region
 }


### PR DESCRIPTION
ref #297 