### PR TITLE
deploy a new private prometheus pool

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -77,9 +77,28 @@ jupyterhub-deployment:
 tofu:
   - 'tofu/**'
 
-# tofu networking
+# terragrunt orchestration / wiring (root config + per-unit terragrunt.hcl)
+terragrunt:
+  - 'tofu/*.hcl'
+  - 'tofu/**/*.hcl'
+
+# reusable tofu modules
+tofu-modules:
+  - 'tofu/modules/**'
+
+# live units for the spring-2025 cluster
+tofu-spring-2025:
+  - 'tofu/spring-2025/**'
+
+# tofu networking (Cloud Router / NAT / egress IP / firewall)
 tofu-network:
-  - 'tofu/network/**'
+  - 'tofu/modules/network/**'
+  - 'tofu/spring-2025/network/**'
+
+# tofu node pools
+tofu-nodepools:
+  - 'tofu/modules/nodepools/**'
+  - 'tofu/spring-2025/*pool*/**'
 
 # add hub-specific labels for deployment changes
 'hub: dvc':

--- a/tofu/modules/nodepools/README.md
+++ b/tofu/modules/nodepools/README.md
@@ -1,0 +1,41 @@
+# tofu/modules/nodepools: private GKE node pools for spring-2025
+
+A reusable module that creates one **private** node pool on the `spring-2025`
+cluster — nodes get internal IPs only, so their outbound traffic flows through
+the Cloud NAT created by [`modules/network`](../network).
+
+## How it fits the migration
+
+The public-to-private migration is build-alongside, not in-place:
+
+1. A unit under `tofu/spring-2025/<role>-pool/` calls this module to create a new
+   private pool next to the existing public one.
+2. The old pool is cordoned and drained onto the new one.
+3. The old (public) pool is deleted once the new one is validated.
+
+So this module only ever **creates** a pool. It never imports or mutates the
+existing public pools, which are not tofu-managed.
+
+Config is meant to mirror the pool being replaced exactly. For a given pool the
+only intended differences from its public predecessor are:
+
+- `enable_private_nodes = true`
+- a date-stamped `pool_name` (house style `<role>-pool-YYYY-MM-DD`)
+
+`pool_name` is also written as the `hub.jupyter.org/pool-name` node label, which
+is the value helm `nodeSelector`s pin. Read `pool_name_selector` from the outputs
+to get the exact `key=value` to update in the paired helm change before draining.
+
+## Zone pinning
+
+`node_locations` must be the single zone where the pool's stateful PD lives
+(`us-central1-b` for both prometheus-data and the NFS disk) so pods can reattach
+their disks after moving pools.
+
+## Provider and versions
+
+This module ships no `provider.tf` or `versions.tf`; Terragrunt generates them
+from `tofu/root.hcl`. Run it through a unit, not directly.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/tofu/modules/nodepools/main.tf
+++ b/tofu/modules/nodepools/main.tf
@@ -1,0 +1,98 @@
+# Reusable module for rebuilding a spring-2025 node pool as a PRIVATE pool (nodes
+# get internal IPs only; egress flows through the Cloud NAT in modules/network).
+#
+# The migration is build-alongside: create a new private pool with this module,
+# drain the old public pool onto it, then delete the old pool. So this module
+# only ever CREATES a pool; it never mutates the existing public pools (which are
+# not tofu-managed). Config mirrors the pool being replaced exactly, changed only
+# by two deltas the caller sets: enable_private_nodes = true and a date-stamped
+# name.
+
+resource "google_container_node_pool" "pool" {
+  name     = var.pool_name
+  cluster  = var.cluster
+  location = var.region # regional cluster: the pool's location is the region
+
+  # Pin the actual node zone(s). Single zone for spring-2025 so stateful pods can
+  # reattach their zonal PDs.
+  node_locations = var.node_locations
+
+  # Matches how the existing pools were created (1 node per zone); the autoscaler
+  # takes over from there.
+  initial_node_count = var.initial_node_count
+
+  autoscaling {
+    min_node_count  = var.min_nodes
+    max_node_count  = var.max_nodes
+    location_policy = var.location_policy
+  }
+
+  max_pods_per_node = var.max_pods_per_node
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  upgrade_settings {
+    strategy        = "SURGE"
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  # The migration delta. Per-pool because the cluster itself is not flipped to
+  # private; each new pool opts in as it is created.
+  network_config {
+    enable_private_nodes = var.enable_private_nodes
+  }
+
+  node_config {
+    machine_type = var.machine_type
+    image_type   = var.image_type
+    disk_type    = var.disk_type
+    disk_size_gb = var.disk_size_gb
+
+    service_account = var.node_service_account
+    oauth_scopes    = var.oauth_scopes
+
+    tags = var.node_tags
+
+    # Kubernetes node labels. hub.jupyter.org/pool-name is the label helm
+    # nodeSelectors pin, so it must equal the pool name; callers can merge in
+    # anything else they need.
+    labels = merge(
+      { "hub.jupyter.org/pool-name" = var.pool_name },
+      var.extra_node_labels,
+    )
+
+    # GCE instance labels — the billing/rollup dimension, keyed on hub.
+    resource_labels = var.resource_labels
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+    }
+
+    kubelet_config {
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled
+    }
+
+    dynamic "taint" {
+      for_each = var.node_taints
+      content {
+        key    = taint.value.key
+        value  = taint.value.value
+        effect = taint.value.effect
+      }
+    }
+  }
+
+  # GKE rewrites node_count as the autoscaler runs; ignore it so applies don't
+  # fight the autoscaler.
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+}

--- a/tofu/modules/nodepools/outputs.tf
+++ b/tofu/modules/nodepools/outputs.tf
@@ -1,0 +1,14 @@
+output "pool_name" {
+  value       = google_container_node_pool.pool.name
+  description = "Name of the created node pool."
+}
+
+output "pool_id" {
+  value       = google_container_node_pool.pool.id
+  description = "Fully qualified GKE node pool ID."
+}
+
+output "pool_name_selector" {
+  value       = "hub.jupyter.org/pool-name=${google_container_node_pool.pool.name}"
+  description = "The node label helm nodeSelectors must pin to schedule onto this pool. Use it when updating the paired helm config before draining the old pool."
+}

--- a/tofu/modules/nodepools/variables.tf
+++ b/tofu/modules/nodepools/variables.tf
@@ -1,0 +1,137 @@
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = "Region of the regional spring-2025 cluster; also the node pool's location. Value comes from root.hcl inputs."
+}
+
+variable "cluster" {
+  type        = string
+  default     = "spring-2025"
+  description = "Name of the GKE cluster this node pool belongs to."
+}
+
+variable "pool_name" {
+  type        = string
+  description = "Node pool name. House style is <role>-pool-YYYY-MM-DD, stamped with the day the pool is created. Also used as the value of the hub.jupyter.org/pool-name node label that helm nodeSelectors pin."
+}
+
+variable "node_locations" {
+  type        = list(string)
+  default     = ["us-central1-b"]
+  description = "Zones the pool places nodes in. Must be a single zone matching any attached zonal PD (prometheus-data and the NFS disk are both in us-central1-b) so stateful pods can reattach."
+}
+
+variable "enable_private_nodes" {
+  type        = bool
+  default     = true
+  description = "Whether nodes get internal IPs only (no external IP). True is the point of the migration; egress then flows through the Cloud NAT in modules/network. Set per-pool because the cluster-level flag is off."
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Compute machine type for the pool's nodes (e.g. n2-standard-8)."
+}
+
+variable "initial_node_count" {
+  type        = number
+  default     = 1
+  description = "Number of nodes created per zone when the pool is first created. The existing pools were created with 1."
+}
+
+variable "min_nodes" {
+  type        = number
+  description = "Autoscaler minimum node count."
+}
+
+variable "max_nodes" {
+  type        = number
+  description = "Autoscaler maximum node count."
+}
+
+variable "location_policy" {
+  type        = string
+  default     = "BALANCED"
+  description = "Autoscaler location policy. BALANCED matches the existing pools."
+}
+
+variable "disk_size_gb" {
+  type        = number
+  default     = 100
+  description = "Boot disk size in GB."
+}
+
+variable "disk_type" {
+  type        = string
+  default     = "pd-balanced"
+  description = "Boot disk type."
+}
+
+variable "image_type" {
+  type        = string
+  default     = "COS_CONTAINERD"
+  description = "Node image type."
+}
+
+variable "max_pods_per_node" {
+  type        = number
+  default     = 110
+  description = "Maximum pods schedulable per node."
+}
+
+variable "node_service_account" {
+  type        = string
+  default     = "default"
+  description = "Service account for the nodes. The existing pools use the default compute SA."
+}
+
+variable "oauth_scopes" {
+  type = list(string)
+  default = [
+    "https://www.googleapis.com/auth/devstorage.read_only",
+    "https://www.googleapis.com/auth/logging.write",
+    "https://www.googleapis.com/auth/monitoring",
+    "https://www.googleapis.com/auth/service.management.readonly",
+    "https://www.googleapis.com/auth/servicecontrol",
+    "https://www.googleapis.com/auth/trace.append",
+  ]
+  description = "OAuth scopes for the node service account. Defaults to the six GKE default scopes carried by the existing pools."
+}
+
+variable "node_tags" {
+  type        = list(string)
+  default     = ["hub-cluster"]
+  description = "Network tags on the nodes. hub-cluster is the custom cluster-wide tag the firewall rules (including the IAP-SSH rule) target."
+}
+
+variable "resource_labels" {
+  type        = map(string)
+  description = "GCE instance labels applied to the nodes (billing/rollup dimension). The repo keys billing on hub; e.g. { hub = \"prometheus\", nodepool-deployment = \"prometheus\" }."
+}
+
+variable "extra_node_labels" {
+  type        = map(string)
+  default     = {}
+  description = "Additional Kubernetes node labels merged in alongside the always-set hub.jupyter.org/pool-name label."
+}
+
+variable "node_taints" {
+  type = list(object({
+    key    = string
+    value  = string
+    effect = string
+  }))
+  default     = []
+  description = "Kubernetes node taints. Empty for nodeSelector-scheduled pools (prometheus/core/support); the user pool sets hub.jupyter.org_dedicated=user:NO_SCHEDULE."
+}
+
+variable "insecure_kubelet_readonly_port_enabled" {
+  # The google provider types this as a string enum, not a bool.
+  type        = string
+  default     = "FALSE"
+  description = "Whether the unauthenticated kubelet read-only port (10255) is open, as the string \"TRUE\" or \"FALSE\". The existing pools have it disabled; keep \"FALSE\"."
+
+  validation {
+    condition     = contains(["TRUE", "FALSE"], var.insecure_kubelet_readonly_port_enabled)
+    error_message = "Must be the string \"TRUE\" or \"FALSE\"."
+  }
+}

--- a/tofu/spring-2025/prometheus-pool/terragrunt.hcl
+++ b/tofu/spring-2025/prometheus-pool/terragrunt.hcl
@@ -1,0 +1,40 @@
+# Phase 1 (canary) of the public-to-private node migration: the private
+# replacement for the existing public prometheus-pool-2025-12-22.
+#
+# Lowest-risk pool to move first — zero user impact (a metrics gap at worst), but
+# stateful enough (the 1000Gi prometheus-data PD must reattach) to prove the full
+# private path: Cloud NAT egress, Private Google Access, and PD reattachment.
+#
+# State key derives from this path: "spring-2025/prometheus-pool". The directory
+# is role-named, not date-stamped, so it stays stable across future recreations;
+# the date-stamped pool NAME lives in inputs below.
+#
+# Parity with the live prometheus-pool-2025-12-22 (describe 2026-06-28); the
+# module defaults carry the shared config, so inputs here are only the
+# prometheus-specific values plus the two migration deltas (private + name).
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../modules/nodepools"
+}
+
+inputs = {
+  pool_name            = "prometheus-pool-2026-06-29"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type = "n2-standard-8"
+  min_nodes    = 1
+  max_nodes    = 3
+  disk_size_gb = 100
+
+  resource_labels = {
+    hub                   = "prometheus"
+    "nodepool-deployment" = "prometheus"
+  }
+}


### PR DESCRIPTION
this creates the shiny, new and PRIVATE `prometheus-pool-2026-06-29` node pool.

no CI/CD for this yet, but i manually deployed this via `terragrunt apply` on my workstation and verified that the two prom node pools (original/public, new/private) are identical.

ref #297 #298