### PR TITLE
migrate the support pool to private nodes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -107,6 +107,9 @@ tofu-prometheus-pool:
 tofu-core-pool:
   - 'tofu/spring-2025/core-pool/**'
 
+tofu-support-pool:
+  - 'tofu/spring-2025/support-pool/**'
+
 # add hub-specific labels for deployment changes
 'hub: dvc':
   - 'deployments/dvc/**'

--- a/hub/templates/home-dirsize-reporter.yaml
+++ b/hub/templates/home-dirsize-reporter.yaml
@@ -33,7 +33,7 @@ spec:
         component: shared-dirsize-metrics
     spec:
       nodeSelector:
-        hub.jupyter.org/pool-name: support-pool-2026-02-12
+        hub.jupyter.org/pool-name: support-pool-2026-07-07
         
       containers:
         - name: dirsize-exporter

--- a/jupyterhub-home-nfs/values.yaml
+++ b/jupyterhub-home-nfs/values.yaml
@@ -113,7 +113,7 @@ jupyterhub-home-nfs:
 
   # Node selector for the deployment
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2026-02-12
+    hub.jupyter.org/pool-name: support-pool-2026-07-07
 
   # Affinity for the deployment - required to pin the pod to us-central1-b where the GKE disk lives
   affinity:

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,12 +1,12 @@
 cert-manager:
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2026-02-12
+    hub.jupyter.org/pool-name: support-pool-2026-07-07
   cainjector:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool-2026-02-12
+      hub.jupyter.org/pool-name: support-pool-2026-07-07
   webhook:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool-2026-02-12
+      hub.jupyter.org/pool-name: support-pool-2026-07-07
   # # Our cluster-internal DNS seems to cache aggressively in
   # # some cases. The cache is also more likely to be warm,
   # # causing issues when cert-manager tries to verify
@@ -77,7 +77,7 @@ prometheus:
   # make sure we collect metrics on pods by app/component at least
   kube-state-metrics:
     nodeSelector:
-      hub.jupyter.org/pool-name: support-pool-2026-02-12
+      hub.jupyter.org/pool-name: support-pool-2026-07-07
     metricLabelsAllowlist:
       - pods=[app,component,hub.jupyter.org/username,app.kubernetes.io/component]
       - nodes=[*]
@@ -110,7 +110,7 @@ prometheus:
 grafana:
   assertNoLeakedSecrets: false
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2026-02-12
+    hub.jupyter.org/pool-name: support-pool-2026-07-07
   deploymentStrategy:
     type: Recreate
 
@@ -172,7 +172,7 @@ grafana:
 
 prometheus-statsd-exporter:
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2026-02-12
+    hub.jupyter.org/pool-name: support-pool-2026-07-07
   service:
     annotations:
       prometheus.io/scrape: "true"
@@ -194,7 +194,7 @@ node-placeholder-scaler:
   calendarOverrideEnabled: True
 
   nodeSelector:
-    hub.jupyter.org/pool-name: support-pool-2026-02-12
+    hub.jupyter.org/pool-name: support-pool-2026-07-07
 
   # cpuThreshold: 0.25 # ignore this as our workloads are memory-bound, not cpu
   memoryThreshold: 0.40 # set this pretty high to avoid overloading nodes and get new ones spun up earlier

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -50,11 +50,11 @@ current as each phase lands.
 | A | `spring-2025/network` (`modules/network`) | Cloud Router + Cloud NAT + reserved egress IP `35.254.232.174`, so private nodes can reach the public internet. | Applied / live |
 | 0 | `spring-2025/network` (`modules/network`, `firewall.tf`) | `spring-2025-allow-iap-ssh` firewall (IAP range `35.235.240.0/20`, tcp:22) so `gcloud compute ssh --tunnel-through-iap` still works once nodes lose external IPs. | Applied / live |
 | 1 | `spring-2025/prometheus-pool` (`modules/nodepools`) | Private `prometheus-pool-2026-06-29` (canary). `prometheus-server` moved onto it (PD reattached across pools); old public `prometheus-pool-2025-12-22` deleted. | Complete |
-| 2 | `spring-2025/core-pool` (`modules/nodepools`) | Private `core-pool-2026-06-30` for every hub's hub/proxy pods plus the shared ingress-nginx controller. `n2-standard-8` (right-sized down from the old pool's `n2-highmem-8` — the workload requested only 35% CPU / 27% mem there; halves RAM 64->32 GB while keeping 8 vCPU for redeploy headroom), `max_pods_per_node = 200`, `cpu_manager_policy = static`, plus the TCP/IP node sysctls. | IaC merged; pool `tg apply` + hub nodeSelector cutover pending |
+| 2 | `spring-2025/core-pool` (`modules/nodepools`) | Private `core-pool-2026-06-30` for every hub's hub/proxy pods plus the shared ingress-nginx controller. `n2-standard-8` (right-sized down from the old pool's `n2-highmem-8` — the workload requested only 35% CPU / 27% mem there; halves RAM 64->32 GB while keeping 8 vCPU for redeploy headroom), `max_pods_per_node = 200`, `cpu_manager_policy = static`, plus the TCP/IP node sysctls. | Complete (2026-07-06 — pool applied, all 42 hubs + ingress cut over via #844, old public `core-pool-2026-03-05` drained + deleted) |
+| 3 | `spring-2025/support-pool` (`modules/nodepools`) | Private `support-pool-2026-07-07` for the shared cluster services (cert-manager, kube-state-metrics, grafana, statsd, node-placeholder-scaler, per-hub dirsize reporters) and the in-cluster NFS server. `n2-standard-4`, module defaults otherwise. **Maintenance window**: the NFS server (`home-nfs`) and grafana carry RWO zonal PDs in `us-central1-b`; moving the NFS server freezes home dirs cluster-wide ~1-3 min. `home-nfs` ships `strategy=RollingUpdate` (not exposed for override by the chart), so its move is handled out of band (patch to `Recreate` / scale-to-0) to avoid a Multi-Attach deadlock. | IaC authored; pool `tg apply` + helm nodeSelector cutover pending (pre-login window) |
 
-The `gpu-pool` is excluded from the migration (idle / scaled to zero). `support-pool`
-(cert-manager, metrics, the in-cluster NFS server) and `user-pool` follow as later
-phases.
+The `gpu-pool` is excluded from the migration (idle / scaled to zero). `user-pool`
+follows as the final phase.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/tofu/spring-2025/support-pool/terragrunt.hcl
+++ b/tofu/spring-2025/support-pool/terragrunt.hcl
@@ -1,0 +1,61 @@
+# Phase 3 of the public-to-private node migration: the private replacement for
+# the existing public support-pool-2026-02-12.
+#
+# The support pool runs the shared cluster services: cert-manager (+cainjector
+# +webhook), kube-state-metrics, grafana, the statsd exporter, the
+# node-placeholder-scaler, every hub's shared-dirsize-metrics reporter, and —
+# the reason this phase is a MAINTENANCE WINDOW — the in-cluster NFS server
+# (jupyterhub-home-nfs) that backs every hub's home directories.
+#
+# Two tenants carry RWO zonal PDs that must reattach on the move:
+#   - jupyterhub-home-nfs  -> disk jupyterhub-homedirs-2026-04-08 (us-central1-b)
+#   - support-grafana      -> its 10Gi standard PD            (us-central1-b)
+# Both disks are zonal in us-central1-b, so this pool pins node_locations there
+# (a zonal PD can't cross zones). During the NFS server's detach/reattach, home
+# directories freeze cluster-wide for ~1-3 min (hard NFS mounts recover; not
+# data loss) — hence the pre-login window.
+#
+# NOTE (operational, not expressible here): the home-nfs Deployment ships with
+# strategy=RollingUpdate, NOT Recreate. With a RWO PD that deadlocks on a
+# cross-pool move (the surged new pod can't attach the disk the old pod still
+# holds -> Multi-Attach). The upstream chart does not expose a strategy override,
+# so the cutover runbook handles it out of band (patch to Recreate / scale-to-0),
+# the same PD-reattach mechanics proven on the prometheus canary. grafana and
+# pushgateway are already strategy=Recreate, so they move cleanly.
+#
+# State key derives from this path: "spring-2025/support-pool". Role-named, not
+# date-stamped, so it stays stable across recreations; the date-stamped pool
+# NAME lives in inputs below.
+#
+# Parity with the live support-pool-2026-02-12 (describe 2026-07-06): the module
+# defaults carry the shared config, so inputs here are only the support-specific
+# values (machine_type n2-standard-4, support billing labels) plus the two
+# migration deltas (private + date-stamped name). support sets no
+# cpu_manager_policy and no node sysctls, so those module defaults are left as-is
+# (unlike core); max_pods_per_node stays the module default 110 (matches live).
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../modules/nodepools"
+}
+
+inputs = {
+  pool_name            = "support-pool-2026-07-07"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type = "n2-standard-4"
+  min_nodes    = 1
+  max_nodes    = 3
+  disk_size_gb = 100
+
+  resource_labels = {
+    hub                   = "support"
+    "nodepool-deployment" = "support"
+  }
+}


### PR DESCRIPTION
ref:  #297 #298 

the timing of this move is important:

1. run `terragrunt apply` in the support-pool module to create the node pool
2. patch the home-nfs deployment so that the nfs volume will properly attach:  `kubectl -n jupyterhub-home-nfs patch deploy home-nfs --type=merge -p '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'`
3. merge this PR
4. profit

i will need to test this pretty thoroughly to ensure things like the nfs homedirs are mounted and writable, as well as confirming grafana etc are happy.

if things aren't happy, here's the rollback plan:

1. revert this PR, merge to `staging`
2. confirm that the nfs PD detaches from the new node to the old/pre-existing one.  if it get stuck, force the detach by scaling the new pool to zero, confirm, then let it come up on the old pool.
3. confirm that all the other support services are on the old node
5. profit