### PR TITLE
Add workshop node pool

### DIFF
--- a/deployments/jupyter/config/common.yaml
+++ b/deployments/jupyter/config/common.yaml
@@ -113,6 +113,9 @@ jupyterhub:
       JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
       # OPENCODE_CONFIG: /etc/opencode-default/opencode.json
     nodeSelector:
+      # uncomment before a workshop to ensure that all users are on the workshop node pool,
+      # and don't forget to comment out user-pool-2026-07-07!
+      # hub.jupyter.org/pool-name: workshop-pool-2026-07-07
       hub.jupyter.org/pool-name: user-pool-2026-07-07
     storage:
       type: static

--- a/support/values.yaml
+++ b/support/values.yaml
@@ -211,3 +211,12 @@ node-placeholder-scaler:
           # This is an example using a GCP n2-highmem-8 node with 64G of RAM allocatable
           memory: 60929654784
       replicas: 1
+    workshop:
+      nodeSelector:
+        hub.jupyter.org/pool-name: workshop-pool-2026-07-07
+      resources:
+        requests:
+          # Some value slightly lower than allocatable RAM on the nodepool
+          # This is an example using a GCP n2d-highmem-16 node with 128G of RAM allocatable
+          memory: 124387962624
+      replicas: 0

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -18,6 +18,7 @@ tofu/
     core-pool/terragrunt.hcl        # -> spring-2025/core-pool
     support-pool/terragrunt.hcl     # -> spring-2025/support-pool
     user-pool/terragrunt.hcl        # -> spring-2025/user-pool
+    workshop-pool/terragrunt.hcl    # -> spring-2025/workshop-pool
 ```
 
 Each leaf `terragrunt.hcl` is a *unit*: it `include`s `root.hcl` and points at a
@@ -57,6 +58,8 @@ current as each phase lands.
 | 4 | `spring-2025/user-pool` (`modules/nodepools`) | Private `user-pool-2026-07-07` for the student singleuser notebook servers (the only pool with a taint, `hub.jupyter.org_dedicated=user:NO_SCHEDULE`) plus the placeholder-scaler's warm spares. `n2-highmem-8`, disk 200 GB, autoscale `min 0 / max 3`, `location_policy = ANY` (all mirroring the live `user-base`). **Graceful cutover, no window**: draining would kill live sessions, so the old pool is not drained. The singleuser + placeholder nodeSelectors are repointed to the new pool (`base-pool` -> `user-pool-2026-07-07`), new spawns land private, and the old `user-base` pool is cordoned and left to empty via the culler (idle 30m / maxAge 12h) before deletion. | Complete (2026-07-07: pool applied, all 22 hubs' singleuser + placeholder nodeSelectors cut over via #860, new spawns verified private on staging + prod, old public `user-base` cordoned then deleted once its last session logged out). This was the final phase: every pool on the cluster now runs private nodes with Cloud NAT egress. |
 
 The `gpu-pool` is excluded from the migration (idle / scaled to zero).
+
+`spring-2025/workshop-pool` (`workshop-pool-2026-07-07`) is a post-migration addition, not a phase: a second private user pool dedicated to workshops, normally scaled to zero. See `spring-2025/README.md`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/tofu/spring-2025/README.md
+++ b/tofu/spring-2025/README.md
@@ -11,7 +11,8 @@ The units:
 - `prometheus-pool/` sources `modules/nodepools`: private `prometheus-pool-2026-06-29` for `prometheus-server`.
 - `core-pool/` sources `modules/nodepools`: private `core-pool-2026-06-30` for every hub's hub/proxy pods and the shared ingress-nginx controller.
 - `support-pool/` sources `modules/nodepools`: private `support-pool-2026-07-07` for the shared cluster services and the in-cluster NFS server.
-- `user-pool/` sources `modules/nodepools`: private `user-pool-2026-07-07` for the student singleuser servers (the only tainted pool).
+- `user-pool/` sources `modules/nodepools`: private `user-pool-2026-07-07` for the student singleuser servers (tainted `...=user`).
+- `workshop-pool/` sources `modules/nodepools`: private `workshop-pool-2026-07-07`, a second user pool dedicated to workshops (same `...=user` taint, so routing is a nodeSelector-only change). Normally scaled to zero (`n2d-highmem-16`, `initial/min 0`, `max 2`); spun up only for a scheduled workshop.
 
 See `../README.md` for the phase-by-phase migration table.
 

--- a/tofu/spring-2025/workshop-pool/terragrunt.hcl
+++ b/tofu/spring-2025/workshop-pool/terragrunt.hcl
@@ -1,0 +1,73 @@
+# A second user pool, dedicated to workshops. Unlike the always-on user pool
+# (which runs the regular student singleuser servers), this pool is normally
+# scaled to zero and costs nothing. It is spun up only when a workshop is
+# scheduled, then scaled back to zero afterward.
+#
+# Sizing (workshop = ~20-50 concurrent users, each 2G guarantee == limit, so no
+# overcommit is possible and a full 100G of ALLOCATABLE memory is needed):
+#   - machine_type n2d-highmem-16 (16 vCPU / 128G). After GKE system + daemonset
+#     reservations a 128G node leaves ~116G allocatable, enough for all 50 users
+#     at 2G on ONE node with headroom. An n2-highmem-8 (64G) only fits ~28, which
+#     would split a 50-person cohort across two nodes. n2d (AMD) is ~10-11%
+#     cheaper than n2 for identical specs; raw n2 pricing is linear so one
+#     highmem-16 costs the same as two highmem-8s, but the single bigger node
+#     wastes less to per-node overhead and keeps the cohort together.
+#   - initial_node_count 0 and min_nodes 0: the pool is created empty. Scale it
+#     up (set max_nodes reached by the autoscaler as pods schedule, or bump
+#     min_nodes for the duration of a workshop) only when a workshop runs.
+#   - max_nodes 2: a safety valve for a 50+ turnout or a straggler pod that can't
+#     fit the first node. The second node only spins up if the first is full.
+#
+# Tainted hub.jupyter.org_dedicated=user:NO_SCHEDULE, the SAME value as the
+# regular user pool. z2jh gives every singleuser pod a default toleration for
+# this taint (scheduling.userPods.tolerations), so routing a workshop onto this
+# pool needs only a nodeSelector change (hub.jupyter.org/pool-name =
+# workshop-pool-2026-07-07) in the hub's singleuser config, no extra toleration.
+# The taint's job is only to keep non-tolerating system pods off this pricey
+# highmem node. Which user pods land here vs. the shared student pool is decided
+# entirely by the nodeSelector, so keep those set deliberately per hub.
+#
+# Private + Cloud NAT egress like every other pool post-migration.
+#
+# State key derives from this path: "spring-2025/workshop-pool". Role-named, not
+# date-stamped, so it stays stable across recreations; the date-stamped pool
+# NAME lives in inputs below.
+#
+# Billing: resource_labels hub=workshop so this pool's node cost rolls up as a
+# distinct line, separate from the shared student pool's hub=base.
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../modules/nodepools"
+}
+
+inputs = {
+  pool_name            = "workshop-pool-2026-07-07"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type       = "n2d-highmem-16"
+  initial_node_count = 0
+  min_nodes          = 0
+  max_nodes          = 2
+  location_policy    = "ANY"
+  disk_size_gb       = 200
+
+  resource_labels = {
+    hub                   = "workshop"
+    "nodepool-deployment" = "workshop"
+  }
+
+  node_taints = [
+    {
+      key    = "hub.jupyter.org_dedicated"
+      value  = "user"
+      effect = "NO_SCHEDULE"
+    },
+  ]
+}


### PR DESCRIPTION
this node pool has been deployed via `terragrunt apply`, but is currently scaled to 0 nodes.

the evening/morning before a workshop, we will scale this pool to 1 node, update the placeholder config to have 1 replica, and `deployments/jupyter/config/common.yaml` to ensure workshop users land on the proper node pool.

ref https://github.com/cal-icor/cal-icor-hubs/issues/863