### PR TITLE
adding dev cluster configs and set up keyless e2e hub deployment pilot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -90,28 +90,43 @@ tofu-modules:
 tofu-spring-2025:
   - 'tofu/clusters/spring-2025/**'
 
+# live units for the dev cluster (throwaway e2e pilot)
+tofu-dev:
+  - 'tofu/clusters/dev/**'
+
+# tofu cluster (control plane / VPC; dev creates its cluster via this module)
+tofu-cluster:
+  - 'tofu/modules/cluster/**'
+  - 'tofu/clusters/dev/cluster/**'
+
 # tofu networking (Cloud Router / NAT / egress IP / firewall)
 tofu-network:
   - 'tofu/modules/network/**'
   - 'tofu/clusters/spring-2025/network/**'
+  - 'tofu/clusters/dev/network/**'
 
 # tofu node pools
 tofu-nodepools:
   - 'tofu/modules/nodepools/**'
   - 'tofu/clusters/spring-2025/*pool*/**'
+  - 'tofu/clusters/dev/*pool*/**'
 
-# per-pool labels (filter migration-phase PRs by which pool they touch)
+# per-pool labels (filter PRs by which pool they touch, across clusters)
 tofu-prometheus-pool:
   - 'tofu/clusters/spring-2025/prometheus-pool/**'
+  - 'tofu/clusters/dev/prometheus-pool/**'
 
 tofu-core-pool:
   - 'tofu/clusters/spring-2025/core-pool/**'
+  - 'tofu/clusters/dev/core-pool/**'
 
 tofu-support-pool:
   - 'tofu/clusters/spring-2025/support-pool/**'
+  - 'tofu/clusters/dev/support-pool/**'
 
 tofu-user-pool:
   - 'tofu/clusters/spring-2025/user-pool/**'
+  - 'tofu/clusters/dev/user-pool/**'
 
 # add hub-specific labels for deployment changes
 'hub: dvc':

--- a/tofu/clusters/dev/README.md
+++ b/tofu/clusters/dev/README.md
@@ -1,0 +1,68 @@
+# dev units
+
+Live Terragrunt units for the `dev` GKE cluster: a throwaway, keyless-CI cluster
+for the end-to-end deploy pilot. Unlike `spring-2025`, this cluster is created by
+tofu (the `cluster/` unit), so the pools take the name from
+`dependency.cluster.outputs.name` rather than a hand-declared `cluster.hcl`.
+
+Each subdirectory is a unit with its own state file (key = its path under
+`tofu/`, e.g. `clusters/dev/network`). A unit `include`s `../../../root.hcl` and
+sources a module from `../../../modules/`.
+
+The units:
+
+- `cluster/` sources `modules/cluster`: its own VPC (`create_network = true`),
+  the subnet, and the zonal GKE cluster in `us-central1-b`. Fresh ranges
+  (`10.10.0.0/22` nodes, `10.96.0.0/14` pods) that cannot collide with prod's
+  default network. `deletion_protection = false` so CI can tear it down.
+- `network/` sources `modules/network`: Cloud Router, Cloud NAT, reserved egress
+  IP, and the IAP-SSH firewall. Depends on `cluster/`.
+- `core-pool/` sources `modules/nodepools`: private `core-pool` (`e2-standard-2`)
+  for the dev hub's hub/proxy pods and the ingress-nginx controller.
+- `support-pool/` sources `modules/nodepools`: private `support-pool`
+  (`e2-standard-2`) for the shared cluster services and the in-cluster NFS server.
+- `prometheus-pool/` sources `modules/nodepools`: private `prometheus-pool`
+  (`e2-medium`) for `prometheus-server`.
+- `user-pool/` sources `modules/nodepools`: private `user-pool` (`e2-medium`,
+  `min 0 / max 1`) for the single dev user's singleuser server (tainted `...=user`).
+
+Everything is downsized from the `spring-2025` baseline: `e2` machine types, 50 GB
+boot disks, tight `max_nodes`, and one user. See each unit for the per-pool notes.
+
+## Standing it up
+
+```bash
+export TG_TF_PATH=tofu
+cd tofu/clusters/dev
+terragrunt run-all plan      # cluster, then network, then the pools
+terragrunt run-all apply     # mutates real infra; review the plan first
+```
+
+`run-all` walks the `dependency` graph: `cluster/` first, then `network/`, then
+the pools. To drive a single unit, `cd` into it and run `terragrunt plan`/`apply`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/tofu/clusters/dev/cluster/terragrunt.hcl
+++ b/tofu/clusters/dev/cluster/terragrunt.hcl
@@ -1,0 +1,30 @@
+# dev: throwaway GKE cluster for the keyless end-to-end deploy pilot. Its own
+# VPC and fresh ranges, so nothing here can collide with prod's default network;
+# deletion_protection off so CI can tear it down and rebuild.
+#
+# Zonal (location = a zone, not the region), single zone us-central1-b, to match
+# where the dev NFS/home-dirs PDs live and to keep the throwaway cluster cheap
+# (one control plane, not three). Node VM sizes are set per pool, downsized.
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../../modules/cluster"
+}
+
+inputs = {
+  cluster_name = "dev"
+
+  # Zonal, not regional: a zone here gives a single-zone cluster in us-central1-b.
+  location = "us-central1-b"
+
+  # Own VPC, fresh non-colliding ranges; CI can tear it down.
+  create_network      = true
+  node_cidr_block     = "10.10.0.0/22"
+  pod_cidr_block      = "10.96.0.0/14"
+  resource_labels     = { hub = "dev" }
+  deletion_protection = false
+}

--- a/tofu/clusters/dev/core-pool/terragrunt.hcl
+++ b/tofu/clusters/dev/core-pool/terragrunt.hcl
@@ -1,0 +1,53 @@
+# dev core-pool: the dev hub's hub + proxy pods and the ingress-nginx
+# controller. Downsized from spring-2025/core-pool for a throwaway cluster.
+#
+# Kept at e2-standard-2 (8 GB), not smaller: ingress-nginx + one hub + its proxy
+# sit on top of ~1.5 GB of GKE system daemons, so 4 GB would be too tight to
+# guarantee the hub schedules.
+#
+# Other deviations from prod, by design for dev:
+#   - no max_pods_per_node override: prod's 200 is for ~42 hubs; dev has one, so
+#     the 110 cluster default is plenty.
+#   - no cpu_manager_policy / DH-3 sysctls: those tune ingress-nginx under real
+#     load; unnecessary on a dev cluster. See spring-2025/core-pool to add them.
+#   - pool_name is role-only, not date-stamped: CI tears down and recreates this
+#     cluster, so a frozen date would go stale on every rebuild.
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../../modules/nodepools"
+}
+
+dependency "cluster" {
+  config_path = "../cluster"
+
+  mock_outputs                            = { name = "mock-cluster" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+# NAT before private nodes, so egress works on first boot.
+dependencies {
+  paths = ["../network"]
+}
+
+inputs = {
+  cluster              = dependency.cluster.outputs.name
+  pool_name            = "core-pool"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type = "e2-standard-2"
+  min_nodes    = 1
+  max_nodes    = 2
+  disk_size_gb = 50
+
+  resource_labels = {
+    hub                   = "core"
+    "nodepool-deployment" = "core"
+  }
+}

--- a/tofu/clusters/dev/network/terragrunt.hcl
+++ b/tofu/clusters/dev/network/terragrunt.hcl
@@ -1,0 +1,33 @@
+# Network unit: Cloud Router, Cloud NAT, reserved egress IP, and the IAP-SSH
+# firewall for this cluster. Private node pools egress through the NAT.
+#
+# Depends on cluster/ for the VPC and to derive resource names, so the NAT and
+# firewall never collide with another cluster's (e.g. spring-2025-*).
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../../modules/network"
+}
+
+dependency "cluster" {
+  config_path = "../cluster"
+
+  mock_outputs = {
+    name         = "mock-cluster"
+    network_name = "mock-network"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+inputs = {
+  network = dependency.cluster.outputs.network_name
+
+  router_name           = "${dependency.cluster.outputs.name}-nat-router"
+  nat_name              = "${dependency.cluster.outputs.name}-nat"
+  nat_egress_ip_name    = "${dependency.cluster.outputs.name}-nat-egress"
+  iap_ssh_firewall_name = "${dependency.cluster.outputs.name}-allow-iap-ssh"
+}

--- a/tofu/clusters/dev/prometheus-pool/terragrunt.hcl
+++ b/tofu/clusters/dev/prometheus-pool/terragrunt.hcl
@@ -1,0 +1,48 @@
+# dev prometheus-pool: prometheus-server (stateful; its data PD reattaches).
+# Downsized from spring-2025/prometheus-pool for a throwaway cluster.
+#
+# machine_type e2-medium (4 GB): the dev cluster scrapes a handful of nodes and
+# one hub, so series cardinality is tiny. This is the pool most likely to need a
+# bump if prometheus OOMs on first spin-up; the fix is one line here to
+# e2-standard-2.
+#
+# pool_name role-only, not date-stamped (CI recreates the cluster).
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../../modules/nodepools"
+}
+
+dependency "cluster" {
+  config_path = "../cluster"
+
+  mock_outputs                            = { name = "mock-cluster" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+# NAT before private nodes, so egress works on first boot.
+dependencies {
+  paths = ["../network"]
+}
+
+inputs = {
+  cluster              = dependency.cluster.outputs.name
+  pool_name            = "prometheus-pool"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type = "e2-medium"
+  min_nodes    = 1
+  max_nodes    = 2
+  disk_size_gb = 50
+
+  resource_labels = {
+    hub                   = "prometheus"
+    "nodepool-deployment" = "prometheus"
+  }
+}

--- a/tofu/clusters/dev/support-pool/terragrunt.hcl
+++ b/tofu/clusters/dev/support-pool/terragrunt.hcl
@@ -1,0 +1,51 @@
+# dev support-pool: the shared cluster services (cert-manager, grafana,
+# kube-state-metrics, the placeholder-scaler) and the in-cluster NFS server.
+# Downsized from spring-2025/support-pool for a throwaway cluster.
+#
+# Kept at e2-standard-2 (8 GB), the one pool not shrunk to 4 GB: it carries the
+# most pods (NFS server + several system services) on top of the GKE daemons, so
+# it gets the safety margin.
+#
+# The NFS server and grafana carry zonal RWO PDs, so node_locations pins the one
+# zone those disks live in (the dev NFS/home-dirs disk is in us-central1-b).
+#
+# pool_name role-only, not date-stamped (CI recreates the cluster).
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../../modules/nodepools"
+}
+
+dependency "cluster" {
+  config_path = "../cluster"
+
+  mock_outputs                            = { name = "mock-cluster" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+# NAT before private nodes, so egress works on first boot.
+dependencies {
+  paths = ["../network"]
+}
+
+inputs = {
+  cluster              = dependency.cluster.outputs.name
+  pool_name            = "support-pool"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type = "e2-standard-2"
+  min_nodes    = 1
+  max_nodes    = 2
+  disk_size_gb = 50
+
+  resource_labels = {
+    hub                   = "support"
+    "nodepool-deployment" = "support"
+  }
+}

--- a/tofu/clusters/dev/user-pool/terragrunt.hcl
+++ b/tofu/clusters/dev/user-pool/terragrunt.hcl
@@ -1,0 +1,60 @@
+# dev user-pool: the single dev user's singleuser server. Downsized from
+# spring-2025/user-pool for a throwaway cluster with exactly one user.
+#
+# The only tainted pool: hub.jupyter.org_dedicated=user:NO_SCHEDULE, so only
+# singleuser servers land here. Scales to zero when idle.
+#
+# Deviations from prod, by design for dev:
+#   - machine_type e2-medium (4 GB): one dev user, one small singleuser pod. The
+#     dev hub's mem_guarantee is set small to match; bump this if it OOMs.
+#   - max_nodes 1: one user means at most one user pod, so one node.
+#   - no placeholder-scaler warm spare: one user needs no pre-warmed node.
+#   - pool_name role-only, not date-stamped (CI recreates the cluster).
+
+include "root" {
+  path           = find_in_parent_folders("root.hcl")
+  merge_strategy = "deep"
+}
+
+terraform {
+  source = "../../../modules/nodepools"
+}
+
+dependency "cluster" {
+  config_path = "../cluster"
+
+  mock_outputs                            = { name = "mock-cluster" }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+}
+
+# NAT before private nodes, so egress works on first boot.
+dependencies {
+  paths = ["../network"]
+}
+
+inputs = {
+  cluster              = dependency.cluster.outputs.name
+  pool_name            = "user-pool"
+  enable_private_nodes = true
+
+  node_locations = ["us-central1-b"]
+
+  machine_type    = "e2-medium"
+  min_nodes       = 0 # scales to zero when the user is not logged in
+  max_nodes       = 1 # exactly one dev user
+  location_policy = "ANY"
+  disk_size_gb    = 50
+
+  resource_labels = {
+    hub                   = "base"
+    "nodepool-deployment" = "base"
+  }
+
+  node_taints = [
+    {
+      key    = "hub.jupyter.org_dedicated"
+      value  = "user"
+      effect = "NO_SCHEDULE"
+    },
+  ]
+}


### PR DESCRIPTION
this is the cluster config for the throwaway `dev` cluster that will be used for acceptance testing for major infrastructure upgrades.

cluster details:
- zonal cluster in us-central1-b with its own VPC (create_network = true) and fresh ranges (10.10.0.0/22 nodes, 10.96.0.0/14 pods).  deletion_protection = false so CI can tear it down.
- NAT, a reserved egress IP, and the IAP-SSH firewall (network unit).
- four private pools mirroring prod's roles, downsized:
  - core-pool: e2-standard-2, min 1 / max 2
  - support-pool: e2-standard-2, min 1 / max 2
  - prometheus-pool: e2-medium, min 1 / max 2
  - user-pool: e2-medium, min 0 / max 1, tainted =user