### PR TITLE
install cert-manager CRDs before the dev support helm deploy

### DIFF
--- a/.github/workflows/deploy-dev-support.yaml
+++ b/.github/workflows/deploy-dev-support.yaml
@@ -47,6 +47,15 @@ jobs:
           location: ${{ vars.DEV_ZONE }}
           project_id: ${{ vars.DEV_PROJECT }}
 
+      # Helm maps every manifest before applying any, so the ClusterIssuer in
+      # support/templates needs these to already exist; the chart's own cert-manager
+      # dependency installs them too late. Version tracks support/requirements.yaml.
+      - name: Install cert-manager CRDs
+        run: |
+          cm=$(awk '/name: cert-manager/{f=1} f&&/version:/{print $2; exit}' support/requirements.yaml)
+          kubectl apply --server-side \
+            -f "https://github.com/cert-manager/cert-manager/releases/download/${cm}/cert-manager.crds.yaml"
+
       - name: Install SOPS
         run: |
           mkdir -p "${HOME}/bin"


### PR DESCRIPTION
The first support deploy to the dev cluster ([run 29280637809](https://github.com/cal-icor/cal-icor-hubs/actions/runs/29280637809)) failed at helm install:

```
Error: unable to build kubernetes objects from release manifest:
resource mapping not found for name: "letsencrypt-prod"
no matches for kind "ClusterIssuer" in version "cert-manager.io/v1"
ensure CRDs are installed first
```

The support chart has a ClusterIssuer in `templates/issuer.yaml` and takes cert-manager as a dependency in `requirements.yaml`. Helm maps every manifest against the API server before it applies any of them, so on a cluster that doesn't already have the cert-manager CRDs, the ClusterIssuer can't be resolved and the install aborts at render. `installCRDs: true` doesn't fix it either: those CRDs would land in the same apply pass, still too late for the mapping.

Prod never hit this because cert-manager started out as its own release there, so the CRDs were already in the cluster by the time it moved into the support chart. The dev cluster is the first time this chart has been installed against an empty cluster.

So: `kubectl apply` the cert-manager CRDs before the helm step. Server-side apply, because the CRDs blow past the annotation size limit on a client-side one. The version is read out of `support/requirements.yaml` so it can't drift from the subchart pin.

The failed run left nothing behind (no release record, no namespace, no CRDs), so there's no cleanup before a retry.

This workflow file doesn't carry a deploying label, so merging won't trigger a run. Re-trigger with a dispatch:

```
gh workflow run deploy-dev.yaml --ref staging \
  -f cluster_command=skip -f deploy_support=true
```

Worth noting that everything upstream of the helm step passed on the first attempt: keyless WIF auth as `dev-deploy`, GKE credentials, GAR helm registry login, `helm dep up` pulling node-placeholder-scaler from the private registry, and sops decrypt with the `sops-dev` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
