### PR TITLE
don't set CRDs in the chart, let the helm command take care of this for us instead

### DIFF
--- a/dev/support-values.yaml
+++ b/dev/support-values.yaml
@@ -5,8 +5,6 @@
 # support/**, which deploys the PROD chart.
 
 cert-manager:
-  # Subchart reads its own scope; prod's top-level --set installCRDs does not reach it.
-  installCRDs: true
   nodeSelector:
     hub.jupyter.org/pool-name: support-pool
   cainjector:


### PR DESCRIPTION
got this error trying to deploy support, and it's due to us having the helm command AND support chart trying to install CRDs:

```
Error: Unable to continue with install: CustomResourceDefinition "certificaterequests.cert-manager.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "support"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "support"
```
