### PR TITLE
fix helm deployment flags

### DIFF
--- a/.github/workflows/deploy-dev-hub.yaml
+++ b/.github/workflows/deploy-dev-hub.yaml
@@ -67,7 +67,7 @@ jobs:
           # release and those are cluster-scoped, so if both releases were named `dev`
           # the second would collide with the first.
           helm upgrade \
-            --install --wait --timeout 15m \
+            --install --timeout 15m \
             --create-namespace --namespace="dev-${ENV}" \
             "dev-${ENV}" hub/ \
             -f deployments/dev/config/common.yaml \

--- a/.github/workflows/deploy-dev-nfs.yaml
+++ b/.github/workflows/deploy-dev-nfs.yaml
@@ -35,11 +35,13 @@ jobs:
           location: ${{ vars.DEV_ZONE }}
           project_id: ${{ vars.DEV_PROJECT }}
 
+      # No --wait here. The chart pins replicas=1 and maxUnavailable=1, which makes helm's
+      # readiness check pass with zero ready pods. kubectl rollout status is the real gate.
       - name: Deploy the jupyterhub-home-nfs chart
         run: |
           helm dep up jupyterhub-home-nfs
           helm upgrade \
-            --install --wait --timeout 10m \
+            --install --timeout 10m \
             --create-namespace --namespace=jupyterhub-home-nfs \
             jupyterhub-home-nfs jupyterhub-home-nfs/ \
             -f dev/nfs-values.yaml

--- a/.github/workflows/deploy-dev-support.yaml
+++ b/.github/workflows/deploy-dev-support.yaml
@@ -74,8 +74,15 @@ jobs:
           helm repo update
           helm dep up support
           helm upgrade \
-            --install --wait --timeout 15m \
+            --install --timeout 15m \
             --create-namespace --namespace=support \
             support support/ \
             -f dev/support-values.yaml \
             -f dev/secrets.yaml
+
+      - name: Wait for the support workloads to actually roll out
+        run: |
+          for w in $(kubectl -n support get deploy,statefulset,daemonset -o name); do
+            kubectl -n support rollout status "$w" --timeout=10m
+          done
+          kubectl get pods -n support


### PR DESCRIPTION
`--wait` didn't really do anything, so we wait for the rollout status to tell us what's up.  this was surfaced when i first deployed the dev cluster's `jupyterhub-home-nfs` chart...  the helm upgrade completed, but the pods hadn't completely spun up before the job ended.