### PR TITLE
workflow updates

### DIFF
--- a/.github/actions/install-sops/action.yaml
+++ b/.github/actions/install-sops/action.yaml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: SOPS release tag.
     required: false
-    default: v3.9.0
+    default: v3.13.2
 
 runs:
   using: composite
@@ -16,8 +16,11 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         mkdir -p "${HOME}/bin"
-        curl -sSL \
+        curl -fsSL \
           "https://github.com/getsops/sops/releases/download/${VERSION}/sops-${VERSION}.linux.amd64" \
           -o "${HOME}/bin/sops"
         chmod 755 "${HOME}/bin/sops"
+        # verify the binary is executable and on the PATH
+        "${HOME}/bin/sops" --version --disable-version-check
+        # this needs to live in the runner's PATH for subsequent steps, so add it to $GITHUB_PATH
         echo "${HOME}/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-dev-cluster.yaml
+++ b/.github/workflows/deploy-dev-cluster.yaml
@@ -5,6 +5,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/deploy-dev-hub.yaml
+++ b/.github/workflows/deploy-dev-hub.yaml
@@ -5,6 +5,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/deploy-dev-nfs-volume.yaml
+++ b/.github/workflows/deploy-dev-nfs-volume.yaml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/deploy-dev-nfs.yaml
+++ b/.github/workflows/deploy-dev-nfs.yaml
@@ -6,6 +6,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/deploy-dev-support.yaml
+++ b/.github/workflows/deploy-dev-support.yaml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -73,7 +77,13 @@ jobs:
 
       - name: Wait for the support workloads to actually roll out
         run: |
-          for w in $(kubectl -n support get deploy,statefulset,daemonset -o name); do
+          workloads=$(kubectl -n support get deploy,statefulset,daemonset -o name)
+          if [[ -z "$workloads" ]]; then
+            echo "No workloads in the support namespace: the chart did not install." >&2
+            exit 1
+          fi
+
+          for w in $workloads; do
             kubectl -n support rollout status "$w" --timeout=10m
           done
           kubectl get pods -n support

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -6,6 +6,10 @@ permissions:
   contents: read
   id-token: write
 
+defaults:
+  run:
+    shell: bash
+
 # The leaf workflows serialize themselves, but only against their own kind. This keeps two
 # runs from interleaving layers against the one shared cluster.
 concurrency:

--- a/.github/workflows/deploy-hubs.yaml
+++ b/.github/workflows/deploy-hubs.yaml
@@ -100,11 +100,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Install SOPS
-        run: |
-          mkdir -p "${HOME}/bin"
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
-          chmod 755 "${HOME}/bin/sops"
-          echo "${HOME}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-sops
 
       - name: Auth to gcloud
         uses: google-github-actions/auth@v3
@@ -204,11 +200,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Install SOPS
-        run: |
-          mkdir -p "${HOME}/bin"
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
-          chmod 755 "${HOME}/bin/sops"
-          echo "${HOME}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-sops
 
       - name: Auth to gcloud
         uses: google-github-actions/auth@v3

--- a/.github/workflows/deploy-jupyterhub-home-nfs.yaml
+++ b/.github/workflows/deploy-jupyterhub-home-nfs.yaml
@@ -52,11 +52,7 @@ jobs:
 
       - name: Install SOPS
         if: ${{ env.DEPLOY }}
-        run: |
-          mkdir -p "${HOME}/bin"
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
-          chmod 755 "${HOME}/bin/sops"
-          echo "${HOME}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-sops
 
       - name: Activate credentials for cluster
         if: ${{ env.DEPLOY }}

--- a/.github/workflows/deploy-support.yaml
+++ b/.github/workflows/deploy-support.yaml
@@ -55,11 +55,7 @@ jobs:
           install_components: 'gke-gcloud-auth-plugin'
 
       - name: Install SOPS
-        run: |
-          mkdir -p "${HOME}/bin"
-          curl -sSL https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 -o "${HOME}/bin/sops"
-          chmod 755 "${HOME}/bin/sops"
-          echo "${HOME}/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-sops
 
       - name: Activate credentials for cluster
         run: |


### PR DESCRIPTION
- fix some false green builds in the dev workflows
- set default shell to bash, as github sets it to `bash -c` which means any `set -x pipefail` args are ignored
- bump sops
- better confirmation of whether or not the sops download succeeded 
- have all existing workflows use the install sops action