### PR TITLE
port a lot of the old bash logic in the workflows to reusable python

### DIFF
--- a/.github/scripts/decide-layers.py
+++ b/.github/scripts/decide-layers.py
@@ -1,0 +1,125 @@
+#! /usr/bin/env python
+"""
+Decide which layers of a deployment's stack run for a given trigger.  A stack is
+one deployment (dev, staging, prod); a layer is one tier within it —
+cluster, support, nfs, nfs-volume, hub.  We can add more stacks in the future for
+other deployments, or more layers to extend an existing one.  This script relies
+on PR labels to direct the workflow to deploy the correct layers.
+
+The caller passes a YAML layer spec in LAYER_SPEC.  On push the decision comes
+from the PR labels and branch; on workflow_dispatch the inputs pass straight
+through.
+
+A shared_branch is a branch that owns a cluster's shared infra.  This is done
+on purpose, as we want to limit when we deploy our core infrastructure (always
+before we deploy actual hubs).  For our prod deployments, this will always be
+'staging'.
+
+Each layer names one GITHUB_OUTPUT key in its output field and sets that key
+when the layer's label is present.  A shared_branch_only layer is set only on
+shared_branch, so merging to any other branch skips it.  A layer with a
+when_on/when_off pair emits those values; one without emits "true"/"false".
+Optional environment_output adds a key set to "prod" on refs/heads/prod, else
+shared_branch.  If any layer's value comes out as "destroy", the plain
+true/false layers are all forced off.
+The calling workflow carries the same spec with per-field comments.
+"""
+
+import argparse
+import os
+import sys
+from collections import OrderedDict, namedtuple
+
+from ruamel.yaml import YAML
+
+_yaml = YAML(typ="safe")
+_yaml.default_flow_style = False
+
+# One layer of the stack, as an immutable record.  Set when_on/when_off to emit
+# custom values; leave them unset and the layer emits "true"/"false".
+Layer = namedtuple(
+    "Layer",
+    ["output", "label", "shared_branch_only", "when_on", "when_off"],
+    defaults=(False, None, None),
+)
+
+
+def _load(text: str) -> dict:
+    """Parse a YAML string into a dict, treating empty input as {}."""
+    return _yaml.load(text) or {}
+
+
+def decide(
+    event: str,
+    ref: str,
+    labels: str,
+    spec: dict,
+    dispatch_inputs: dict,
+) -> "OrderedDict[str, str]":
+    """Return the output key -> value map for one trigger."""
+    layers = [Layer(**item) for item in spec["layers"]]
+    shared_branch = spec["shared_branch"]
+    env_output = spec.get("environment_output")
+    results: OrderedDict[str, str] = OrderedDict()
+
+    if event == "workflow_dispatch":
+        for layer in layers:
+            results[layer.output] = dispatch_inputs[layer.output]
+        if env_output:
+            results[env_output] = dispatch_inputs[env_output]
+    else:
+        present = set(labels.split())
+        on_shared_branch = ref == f"refs/heads/{shared_branch}"
+        for layer in layers:
+            enabled = layer.label in present and (
+                not layer.shared_branch_only or on_shared_branch
+            )
+            if layer.when_on is not None:
+                results[layer.output] = layer.when_on if enabled else layer.when_off
+            else:
+                results[layer.output] = "true" if enabled else "false"
+        if env_output:
+            results[env_output] = "prod" if ref == "refs/heads/prod" else shared_branch
+
+    # A destroyed stack has nothing to deploy into.
+    destroying = any(
+        layer.when_on is not None and results[layer.output] == "destroy"
+        for layer in layers
+    )
+    if destroying:
+        for layer in layers:
+            if layer.when_on is None:
+                results[layer.output] = "false"
+
+    return results
+
+
+def main(args: argparse.Namespace) -> None:
+    results = decide(
+        event=os.environ.get("EVENT", ""),
+        ref=os.environ.get("REF", ""),
+        labels=os.environ.get("LABELS", ""),
+        spec=_load(os.environ["LAYER_SPEC"]),
+        dispatch_inputs=_load(os.environ.get("DISPATCH_INPUTS", "")),
+    )
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as fh:
+            for key, value in results.items():
+                fh.write(f"{key}={value}\n")
+
+    print("  ".join(f"{key}: {value}" for key, value in results.items()))
+    if args.debug:
+        _yaml.dump(results, sys.stdout)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--debug",
+        "-d",
+        action="store_true",
+        help="Also print the decision as YAML.",
+    )
+    main(parser.parse_args())

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -68,77 +68,65 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install the YAML parser
+        run: pip install ruamel.yaml==0.19.1
+
+      # This spec is the whole dev-specific part; decide-layers.py just reads it,
+      # so prod reuses the script with its own spec. Fields: output = the
+      # GITHUB_OUTPUT key the layer sets, label = the PR label that turns it on,
+      # shared_branch_only = deploys from shared_branch alone (a prod merge skips
+      # it), when_on/when_off = the strings a value layer emits (a layer without
+      # them emits true/false). environment_output = prod on prod, else staging.
       - name: Decide which layers to run
         id: decide
         env:
           EVENT: ${{ github.event_name }}
           REF: ${{ github.ref }}
           LABELS: ${{ steps.pr-labels.outputs.labels }}
-          CMD: ${{ inputs.cluster_command }}
-          SUPPORT: ${{ inputs.deploy_support }}
-          NFS: ${{ inputs.deploy_nfs }}
-          NFS_VOLUME: ${{ inputs.deploy_nfs_volume }}
-          HUB: ${{ inputs.deploy_hub }}
-          HUB_ENV: ${{ inputs.hub_environment }}
-        run: |
-          if [[ "$EVENT" == "workflow_dispatch" ]]; then
-            cluster_command="$CMD"
-            deploy_support="$SUPPORT"
-            deploy_nfs="$NFS"
-            deploy_nfs_volume="$NFS_VOLUME"
-            deploy_hub="$HUB"
-            hub_environment="$HUB_ENV"
-          else
-            cluster_command=skip
-            deploy_support=false
-            deploy_nfs=false
-            deploy_nfs_volume=false
-            deploy_hub=false
-
-            if [[ "$REF" == "refs/heads/prod" ]]; then
-              hub_environment=prod
-            else
-              hub_environment=staging
-            fi
-
-            for label in $LABELS; do
-              case "$label" in
-                tofu-dev)       cluster_command=apply ;;
-                support-dev)    deploy_support=true ;;
-                nfs-dev)        deploy_nfs=true ;;
-                nfs-volume-dev) deploy_nfs_volume=true ;;
-                hub-dev)        deploy_hub=true ;;
-              esac
-            done
-
-            # The shared layers deploy from staging only, so a prod merge promotes the
-            # hub and nothing else.
-            if [[ "$REF" == "refs/heads/prod" ]]; then
-              cluster_command=skip
-              deploy_support=false
-              deploy_nfs=false
-              deploy_nfs_volume=false
-            fi
-          fi
-
-          # A destroy leaves nothing for the helm layers to deploy into.
-          if [[ "$cluster_command" == "destroy" ]]; then
-            deploy_support=false
-            deploy_nfs=false
-            deploy_nfs_volume=false
-            deploy_hub=false
-          fi
-
-          {
-            echo "cluster_command=$cluster_command"
-            echo "deploy_support=$deploy_support"
-            echo "deploy_nfs=$deploy_nfs"
-            echo "deploy_nfs_volume=$deploy_nfs_volume"
-            echo "deploy_hub=$deploy_hub"
-            echo "hub_environment=$hub_environment"
-          } >> "$GITHUB_OUTPUT"
-          echo "Cluster: $cluster_command  Support: $deploy_support  NFS: $deploy_nfs" \
-               "NFS volume: $deploy_nfs_volume  Hub: $deploy_hub ($hub_environment)"
+          LAYER_SPEC: |
+            shared_branch: staging
+            environment_output: hub_environment
+            layers:
+              # tofu cluster: apply or skip, and destroy via dispatch.
+              - output: cluster_command
+                label: tofu-dev
+                shared_branch_only: true
+                when_on: apply
+                when_off: skip
+              # support chart.
+              - output: deploy_support
+                label: support-dev
+                shared_branch_only: true
+              # in-cluster NFS server.
+              - output: deploy_nfs
+                label: nfs-dev
+                shared_branch_only: true
+              # NFS home-directory volume/PV layer.
+              - output: deploy_nfs_volume
+                label: nfs-volume-dev
+                shared_branch_only: true
+              # the hub itself: promoted per-branch (staging->staging, prod->prod).
+              - output: deploy_hub
+                label: hub-dev
+                shared_branch_only: false
+          DISPATCH_INPUTS: |
+            cluster_command: "${{ inputs.cluster_command }}"
+            deploy_support: "${{ inputs.deploy_support }}"
+            deploy_nfs: "${{ inputs.deploy_nfs }}"
+            deploy_nfs_volume: "${{ inputs.deploy_nfs_volume }}"
+            deploy_hub: "${{ inputs.deploy_hub }}"
+            hub_environment: "${{ inputs.hub_environment }}"
+        run: python .github/scripts/decide-layers.py
 
   # Each job below runs if no layer before it failed (skipped is fine) and the gate says to.
   cluster:

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -10,8 +10,7 @@ defaults:
   run:
     shell: bash
 
-# The leaf workflows serialize themselves, but only against their own kind. This keeps two
-# runs from interleaving layers against the one shared cluster.
+# Serialize the whole stack; leaf workflows only serialize against themselves.
 concurrency:
   group: dev-stack
   cancel-in-progress: false
@@ -81,12 +80,8 @@ jobs:
       - name: Install the YAML parser
         run: pip install ruamel.yaml==0.19.1
 
-      # This spec is the whole dev-specific part; decide-layers.py just reads it,
-      # so prod reuses the script with its own spec. Fields: output = the
-      # GITHUB_OUTPUT key the layer sets, label = the PR label that turns it on,
-      # shared_branch_only = deploys from shared_branch alone (a prod merge skips
-      # it), when_on/when_off = the strings a value layer emits (a layer without
-      # them emits true/false). environment_output = prod on prod, else staging.
+      # The dev spec decide-layers.py reads; prod passes its own. Field
+      # definitions are in the script's docstring.
       - name: Decide which layers to run
         id: decide
         env:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,7 @@ niquests==3.7.2
 pre-commit==4.6.0
 pygithub==2.4.0
 pyrsistent==0.19.3
+pytest==9.1.1
 ruamel.yaml==0.19.1
 ruff==0.7.0
 urllib3==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ niquests==3.7.2
 pre-commit==4.6.0
 pygithub==2.4.0
 pyrsistent==0.19.3
+pytest==9.1.1
+ruamel.yaml==0.19.1
 urllib3==2.7.0
 yamllint==1.35.1


### PR DESCRIPTION
ripping out a ton of bash in to a python helper script.  this will allow us to re-use this script in more than one full-stay deploy workflow, and minimize copy/pasting and bash syntax drift over time