### PR TITLE
bump node placeholder scaler to latest version for testing

### DIFF
--- a/support/requirements.yaml
+++ b/support/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: node-placeholder-scaler
-    version: 0.0.1-0.dev.git.422.h67ce622
+    version: 0.0.1-0.dev.git.424.h1c64a4b
     repository: oci://us-central1-docker.pkg.dev/cal-icor-hubs/helm-charts
   - name: prometheus-statsd-exporter
     version: 0.11.0


### PR DESCRIPTION
ref https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/pull/28

in particular, this change:  https://github.com/berkeley-dsep-infra/jupyterhub-k8s-node-placeholder/pull/28/changes/fb6c50e925609190e1eddc3176132a247c26c41f#diff-307cd991826c922710cb58c5318c0f764c05b9af380ae0f16dc49948778053edR467

this bumps the grace period from 5m to 10m, which more accurately reflects the amount of time it takes for a new node to spin up.