### PR TITLE
new spring 2025 deployment workflows

### DIFF
--- a/.github/scripts/decide-layers.py
+++ b/.github/scripts/decide-layers.py
@@ -24,6 +24,13 @@ the spec fields:
                       this run.  A layer cannot deploy into a missing cluster.
                       A requested layer skipped this way is reported as a
                       GitHub Actions notice annotation.
+  destroy_label       on push, this label on the merged PR makes the layer emit
+                      "destroy" instead of its on/off value (gated the same as
+                      the layer's own label).  Only meaningful on a when_on
+                      layer whose leaf understands "destroy" (the cluster).  It
+                      is the only path to a teardown: dispatch offers no destroy
+                      choice, so prod can only be torn down through a labelled,
+                      reviewable PR.
   environment_output  set to "prod" on refs/heads/prod, else shared_branch.
 
 A "destroy" value forces every plain true/false layer off.  The calling workflow
@@ -52,8 +59,9 @@ Layer = namedtuple(
         "when_off",
         "implied_by",
         "requires",
+        "destroy_label",
     ],
-    defaults=(False, None, None, None, None),
+    defaults=(None, False, None, None, None, None, None),
 )
 
 
@@ -96,11 +104,18 @@ def decide(
         present = set(labels.split())
         on_shared_branch = ref == f"refs/heads/{shared_branch}"
         for layer in layers:
-            enabled = layer.label in present and (
-                not layer.shared_branch_only or on_shared_branch
-            )
+            gated_on = not layer.shared_branch_only or on_shared_branch
+            enabled = layer.label in present and gated_on
             if layer.when_on is not None:
-                results[layer.output] = layer.when_on if enabled else layer.when_off
+                # A destroy label (same branch gating) overrides apply/skip.
+                if (
+                    layer.destroy_label is not None
+                    and layer.destroy_label in present
+                    and gated_on
+                ):
+                    results[layer.output] = "destroy"
+                else:
+                    results[layer.output] = layer.when_on if enabled else layer.when_off
             else:
                 results[layer.output] = "true" if enabled else "false"
         if env_output:

--- a/.github/workflows/deploy-spring-2025-cluster.yaml
+++ b/.github/workflows/deploy-spring-2025-cluster.yaml
@@ -1,0 +1,93 @@
+name: Deploy spring-2025 cluster (tofu)
+# Converges or tears down the spring-2025 tofu units in tofu/clusters/spring-2025.
+#
+# IMPORTANT: spring-2025's control plane was created imperatively with
+# `gcloud container clusters create` (regional), NOT tofu, so there is no
+# cluster/ unit here. `run --all` converges only the network + node pools;
+# a destroy tears down pools+network (still an outage), never the control plane.
+# Because the control plane is never recreated, prod-deploy@'s cluster-admin
+# RBAC binding never drops, so there is no post-apply RBAC reapply.
+#
+# destroy is reachable only via workflow_call with command=destroy, which the
+# orchestrator emits from a merged PR carrying tofu-destroy-spring-2025. This
+# leaf's own dispatch offers no destroy choice.
+
+permissions:
+  contents: read
+  id-token: write
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        description: "plan, apply, or destroy"
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "terragrunt run --all command"
+        type: choice
+        options: [apply, plan]
+        default: plan
+
+concurrency:
+  group: spring-2025-cluster-tofu # serialize applies; the GCS backend also locks state
+  cancel-in-progress: false
+
+env:
+  TOFU_VERSION: "1.12.3"
+  TERRAGRUNT_VERSION: "1.1.0"
+  TG_TF_PATH: tofu
+  TG_NON_INTERACTIVE: "true"
+
+jobs:
+  tofu:
+    runs-on: ubuntu-latest
+    environment: prod-infra
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.PROD_WIF_PROVIDER }}
+          service_account: ${{ vars.PROD_INFRA_SA }}
+
+      # An apply plans first; a failure here skips the apply below.
+      - name: terragrunt run --all plan
+        if: ${{ inputs.command == 'plan' || inputs.command == 'apply' }}
+        uses: gruntwork-io/terragrunt-action@v3
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+          tg_version: ${{ env.TERRAGRUNT_VERSION }}
+          tg_dir: tofu/clusters/spring-2025
+          tg_command: run --all plan
+          tg_add_approve: "0"
+
+      - name: terragrunt run --all apply
+        if: ${{ inputs.command == 'apply' }}
+        uses: gruntwork-io/terragrunt-action@v3
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+          tg_version: ${{ env.TERRAGRUNT_VERSION }}
+          tg_dir: tofu/clusters/spring-2025
+          tg_command: run --all apply
+          tg_add_approve: "0"
+
+      # Tears down pools+network only (the control plane is gcloud-made). Reached
+      # only through a merged PR labelled tofu-destroy-spring-2025.
+      - name: terragrunt run --all destroy
+        if: ${{ inputs.command == 'destroy' }}
+        uses: gruntwork-io/terragrunt-action@v3
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+          tg_version: ${{ env.TERRAGRUNT_VERSION }}
+          tg_dir: tofu/clusters/spring-2025
+          tg_command: run --all destroy
+          tg_add_approve: "0"

--- a/.github/workflows/deploy-spring-2025-hub.yaml
+++ b/.github/workflows/deploy-spring-2025-hub.yaml
@@ -1,0 +1,136 @@
+name: Deploy spring-2025 hubs (hubploy)
+# Deploys hubs to the spring-2025 cluster with keyless hubploy (ADC, no key).
+# A lightweight determine job resolves the hub list and outputs it as a JSON
+# array; the deploy job fans out one runner per hub with fail-fast disabled.
+#
+# When `hub` is set (dispatch) exactly that hub deploys; otherwise the list is
+# resolved from the merge commit's labels via determine-hub-deployments.py.
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write  # mint the OIDC token for keyless WIF auth
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "staging or prod"
+        type: string
+        required: true
+      hub:
+        description: "A single hub to deploy; empty resolves the list from labels"
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "staging or prod"
+        type: choice
+        options: [staging, prod]
+        default: staging
+      hub:
+        description: "A single hub to deploy; empty resolves the list from labels"
+        type: string
+        default: ""
+
+concurrency:
+  group: spring-2025-hub-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  determine-hubs:
+    runs-on: ubuntu-latest
+    outputs:
+      hubs: ${{ steps.set-hubs.outputs.hubs }}
+    steps:
+      - name: Get PR labels
+        id: pr-labels
+        if: github.event_name == 'push' && inputs.hub == ''
+        uses: irby/get-labels-on-push@v1.2.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Determine hubs to deploy
+        id: set-hubs
+        run: |
+          if [[ -n "${{ inputs.hub }}" ]]; then
+            echo "hubs=[\"${{ inputs.hub }}\"]" >> "$GITHUB_OUTPUT"
+          else
+            # `dev` is the dev CLUSTER's hub and must never deploy here. The script
+            # reads the GITHUB_PR_LABEL_HUB_* env vars set from the merge commit's
+            # labels; both the all-hubs labels and a per-hub label land on prod.
+            hubs=$(python .github/scripts/determine-hub-deployments.py \
+                     --ignore gpu-demo rstudio dev \
+                   | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "hubs=${hubs}" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: determine-hubs
+    if: needs.determine-hubs.outputs.hubs != '[]'
+    strategy:
+      matrix:
+        hub: ${{ fromJson(needs.determine-hubs.outputs.hubs) }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install SOPS
+        uses: ./.github/actions/install-sops
+
+      # gke-auth (auth@v3 + get-gke-credentials) writes ADC for hubploy AND a
+      # kubeconfig, so the confirm step below can run kubectl. hubploy still
+      # mints its own kubeconfig; the extra context does not interfere.
+      - name: Authenticate to the cluster (keyless WIF)
+        uses: ./.github/actions/gke-auth
+        with:
+          workload_identity_provider: ${{ vars.PROD_WIF_PROVIDER }}
+          service_account: ${{ vars.PROD_DEPLOY_SA }}
+          cluster_name: ${{ vars.PROD_CLUSTER }}
+          location: ${{ vars.PROD_ZONE }}
+          project_id: ${{ vars.PROD_PROJECT }}
+
+      - name: Deploy ${{ matrix.hub }} to ${{ inputs.environment }}
+        run: |
+          echo "Deploying ${{ matrix.hub }} to ${{ inputs.environment }}"
+          hubploy --verbose deploy --timeout 30m "${{ matrix.hub }}" hub "${{ inputs.environment }}"
+
+      - name: Confirm the ${{ matrix.hub }} pods rolled out
+        run: |
+          set -euo pipefail
+          ns="${{ matrix.hub }}-${{ inputs.environment }}"
+          # Process substitution keeps the loop in this shell, so a failed
+          # rollout trips set -e instead of being swallowed by a pipe subshell.
+          while IFS= read -r res; do
+            kubectl -n "$ns" rollout status "$res" --timeout=10m
+          done < <(kubectl -n "$ns" get deploy,statefulset,daemonset -o name)
+          kubectl -n "$ns" get pods

--- a/.github/workflows/deploy-spring-2025-nfs.yaml
+++ b/.github/workflows/deploy-spring-2025-nfs.yaml
@@ -1,0 +1,58 @@
+name: Deploy spring-2025 jupyterhub-home-nfs chart (helm)
+# Installs the home-directory NFS server on the spring-2025 cluster with raw helm.
+
+permissions:
+  contents: read
+  id-token: write  # mint the OIDC token for keyless WIF auth
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: spring-2025-nfs-helm
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Authenticate to the cluster (keyless WIF)
+        uses: ./.github/actions/gke-auth
+        with:
+          workload_identity_provider: ${{ vars.PROD_WIF_PROVIDER }}
+          service_account: ${{ vars.PROD_DEPLOY_SA }}
+          cluster_name: ${{ vars.PROD_CLUSTER }}
+          location: ${{ vars.PROD_ZONE }}
+          project_id: ${{ vars.PROD_PROJECT }}
+
+      - name: Install SOPS
+        uses: ./.github/actions/install-sops
+
+      - name: Decrypt jupyterhub-home-nfs secrets
+        run: sops -d -i jupyterhub-home-nfs/secrets/quota-overrides.yaml
+
+      # No --wait here. The chart pins replicas=1 and maxUnavailable=1, which makes helm's
+      # readiness check pass with zero ready pods. kubectl rollout status is the real gate.
+      - name: Deploy the jupyterhub-home-nfs chart
+        run: |
+          helm dep up jupyterhub-home-nfs
+          helm upgrade \
+            --install --timeout 10m \
+            --create-namespace --namespace=jupyterhub-home-nfs \
+            jupyterhub-home-nfs jupyterhub-home-nfs/ \
+            --values jupyterhub-home-nfs/values.yaml \
+            --values jupyterhub-home-nfs/secrets/quota-overrides.yaml
+
+      - name: Wait for the NFS server to actually roll out
+        run: |
+          kubectl rollout status deployment/home-nfs \
+            -n jupyterhub-home-nfs --timeout=10m
+          kubectl get pods -n jupyterhub-home-nfs

--- a/.github/workflows/deploy-spring-2025-support.yaml
+++ b/.github/workflows/deploy-spring-2025-support.yaml
@@ -1,0 +1,72 @@
+name: Deploy spring-2025 support helm chart
+# Deploys the support chart (cert-manager, ingress-nginx, prometheus, grafana,
+# statsd) to the spring-2025 cluster via keyless WIF and raw helm.
+
+permissions:
+  contents: read
+  id-token: write  # mint the OIDC token for keyless WIF auth
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: spring-2025-support
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Authenticate to the cluster (keyless WIF)
+        id: auth
+        uses: ./.github/actions/gke-auth
+        with:
+          workload_identity_provider: ${{ vars.PROD_WIF_PROVIDER }}
+          service_account: ${{ vars.PROD_DEPLOY_SA }}
+          cluster_name: ${{ vars.PROD_CLUSTER }}
+          location: ${{ vars.PROD_ZONE }}
+          project_id: ${{ vars.PROD_PROJECT }}
+          token_format: access_token
+
+      - name: Install SOPS
+        uses: ./.github/actions/install-sops
+
+      - name: Log in to the GAR helm registry (keyless)
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: |
+          printf '%s' "$ACCESS_TOKEN" \
+            | helm registry login -u oauth2accesstoken --password-stdin \
+              https://us-central1-docker.pkg.dev
+
+      - name: Deploy support helm chart
+        run: |
+          sops -d -i support/secrets.yaml
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+          helm dep up support
+          helm upgrade \
+            --install --wait --create-namespace \
+            --namespace=support \
+            support support/ \
+            -f support/secrets.yaml
+
+      - name: Confirm the support workloads rolled out
+        run: |
+          set -euo pipefail
+          # Process substitution keeps the loop in this shell, so a failed
+          # rollout trips set -e instead of being swallowed by a pipe subshell.
+          while IFS= read -r res; do
+            kubectl -n support rollout status "$res" --timeout=10m
+          done < <(kubectl -n support get deploy,statefulset,daemonset -o name)
+          kubectl -n support get pods

--- a/.github/workflows/deploy-spring-2025.yaml
+++ b/.github/workflows/deploy-spring-2025.yaml
@@ -1,0 +1,187 @@
+name: Deploy spring-2025 cluster stack
+# Single entry point for the prod (spring-2025) cluster.
+# Order of operations:  cluster (tofu) -> support -> nfs -> hub.
+
+permissions:
+  contents: read
+  id-token: write
+
+defaults:
+  run:
+    shell: bash
+
+# Serialize the whole stack; leaf workflows only serialize against themselves.
+concurrency:
+  group: spring-2025-stack
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_command:
+        description: "What to do with the cluster (destroy is PR-label-only)"
+        type: choice
+        options: [skip, plan, apply]
+        default: plan
+      deploy_support:
+        description: "Deploy the support chart afterwards"
+        type: boolean
+        default: false
+      deploy_nfs:
+        description: "Deploy the jupyterhub-home-nfs chart afterwards"
+        type: boolean
+        default: false
+      deploy_hub:
+        description: "Deploy a hub (choose which one below)"
+        type: boolean
+        default: false
+      hub:
+        description: "Which hub to deploy (dispatch only; push uses the label matrix)"
+        type: string
+        default: jupyter
+      hub_environment:
+        description: "Which hub environment to deploy"
+        type: choice
+        options: [staging, prod]
+        default: staging
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      cluster_command: ${{ steps.decide.outputs.cluster_command }}
+      deploy_support: ${{ steps.decide.outputs.deploy_support }}
+      deploy_nfs: ${{ steps.decide.outputs.deploy_nfs }}
+      deploy_hub: ${{ steps.decide.outputs.deploy_hub }}
+      hub_environment: ${{ steps.decide.outputs.hub_environment }}
+    steps:
+      - name: Get PR labels
+        id: pr-labels
+        if: github.event_name == 'push'
+        uses: irby/get-labels-on-push@v1.2.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install the YAML parser
+        run: pip install ruamel.yaml==0.19.1
+
+      # Read-only cluster existence check. Bare auth@v3, NOT the gke-auth
+      # composite, whose get-gke-credentials is the call that fails on a
+      # missing cluster. PROD_DEPLOY_SA holds container.clusterViewer.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.PROD_WIF_PROVIDER }}
+          service_account: ${{ vars.PROD_DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      # Emit the cluster's layer key when it is RUNNING, else nothing, so the
+      # gate skips layers that would deploy into a cluster that isn't there.
+      # spring-2025 is REGIONAL, so this is --location, not dev's --zone.
+      - name: Probe cluster existence
+        id: probe
+        run: |
+          if gcloud container clusters describe "${{ vars.PROD_CLUSTER }}" \
+               --location "${{ vars.PROD_ZONE }}" --project "${{ vars.PROD_PROJECT }}" \
+               --format='value(status)' 2>/dev/null | grep -qx RUNNING; then
+            echo "backends=cluster_command" >> "$GITHUB_OUTPUT"
+          else
+            echo "backends=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The prod spec decide-layers.py reads. Field definitions are in the
+      # script's docstring.
+      - name: Decide which layers to run
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          LABELS: ${{ steps.pr-labels.outputs.labels }}
+          BACKENDS_PRESENT: ${{ steps.probe.outputs.backends }}
+          LAYER_SPEC: |
+            shared_branch: staging
+            environment_output: hub_environment
+            layers:
+              # tofu cluster: apply or skip on push; destroy only via a merged PR
+              # carrying tofu-destroy-spring-2025 (no dispatch/push destroy path).
+              # Converges pools+network only -- the control plane is gcloud-made.
+              - output: cluster_command
+                label: tofu-spring-2025
+                destroy_label: tofu-destroy-spring-2025
+                shared_branch_only: true
+                when_on: apply
+                when_off: skip
+              # support chart.
+              - output: deploy_support
+                label: support-deployment
+                shared_branch_only: true
+                requires: cluster_command
+              # in-cluster NFS server.
+              - output: deploy_nfs
+                label: jupyterhub-home-nfs-deployment
+                shared_branch_only: true
+                requires: cluster_command
+              # the hubs. On dispatch a single hub is chosen via the `hub` input
+              # (passed straight to the leaf). No push label yet: the label
+              # matrix is wired when the push: trigger is turned on.
+              - output: deploy_hub
+                shared_branch_only: false
+                requires: cluster_command
+          DISPATCH_INPUTS: |
+            cluster_command: "${{ inputs.cluster_command }}"
+            deploy_support: "${{ inputs.deploy_support }}"
+            deploy_nfs: "${{ inputs.deploy_nfs }}"
+            deploy_hub: "${{ inputs.deploy_hub }}"
+            hub_environment: "${{ inputs.hub_environment }}"
+        run: python .github/scripts/decide-layers.py
+
+  # Each job below runs if no layer before it failed (skipped is fine) and the gate says to.
+  cluster:
+    needs: gate
+    if: ${{ needs.gate.outputs.cluster_command != 'skip' }}
+    uses: ./.github/workflows/deploy-spring-2025-cluster.yaml
+    with:
+      command: ${{ needs.gate.outputs.cluster_command }}
+    permissions:
+      contents: read
+      id-token: write
+
+  support:
+    needs: [gate, cluster]
+    if: ${{ !cancelled() && !failure() && needs.gate.outputs.deploy_support == 'true' }}
+    uses: ./.github/workflows/deploy-spring-2025-support.yaml
+    permissions:
+      contents: read
+      id-token: write
+
+  nfs:
+    needs: [gate, cluster, support]
+    if: ${{ !cancelled() && !failure() && needs.gate.outputs.deploy_nfs == 'true' }}
+    uses: ./.github/workflows/deploy-spring-2025-nfs.yaml
+    permissions:
+      contents: read
+      id-token: write
+
+  hub:
+    needs: [gate, cluster, support, nfs]
+    if: ${{ !cancelled() && !failure() && needs.gate.outputs.deploy_hub == 'true' }}
+    uses: ./.github/workflows/deploy-spring-2025-hub.yaml
+    with:
+      environment: ${{ needs.gate.outputs.hub_environment }}
+      hub: ${{ inputs.hub }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read


### PR DESCRIPTION
this will be an evolution of the gated workflow used to deploy the dev cluster (https://github.com/cal-icor/cal-icor-hubs/blob/staging/.github/workflows/deploy-dev.yaml).

on a PR merge, labels are scanned and then the workflow path(s) are decided by the gate.

the order in which the layers of the spring-2025 stack are deployed **mostly** matters.  the only things that need to be run in sequence are:  `cluster creation --> (support and or nfs) -- > hubs`

so, for this methodology, i decided to enforce a fully sequential order:  `cluster creation --> support --> nfs -- > hubs`

this way, even though it doesn't matter if nfs is spun up before or after the support chart, there will always be order among the chaos.

NOTE:  this version of the workflows does not act based on PR labels...  yet.  i want to test redeployment of things via dispatch before moving all the workflows over.