### PR TITLE
disable pre spawn auth refresh

### DIFF
--- a/deployments/chicostate/config/common.yaml
+++ b/deployments/chicostate/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://shibboleth.csuchico.edu/idp/shibboleth:

--- a/deployments/chicostate/config/common.yaml
+++ b/deployments/chicostate/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://shibboleth.csuchico.edu/idp/shibboleth:
             default: true

--- a/deployments/csub/config/common.yaml
+++ b/deployments/csub/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://shib.csub.edu/idp/shibboleth:

--- a/deployments/csub/config/common.yaml
+++ b/deployments/csub/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://shib.csub.edu/idp/shibboleth:
             default: true

--- a/deployments/csueb/config/common.yaml
+++ b/deployments/csueb/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://vince.csueastbay.edu/idp/shibboleth:
             default: true

--- a/deployments/csueb/config/common.yaml
+++ b/deployments/csueb/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://vince.csueastbay.edu/idp/shibboleth:

--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -28,6 +28,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://shibboleth.fullerton.edu/idp/shibboleth:
             default: true

--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -28,6 +28,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://shibboleth.fullerton.edu/idp/shibboleth:

--- a/deployments/csufresno/config/common.yaml
+++ b/deployments/csufresno/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://shib-idp.its.csufresno.edu/idp/shibboleth:
             default: true

--- a/deployments/csufresno/config/common.yaml
+++ b/deployments/csufresno/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://shib-idp.its.csufresno.edu/idp/shibboleth:

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://idpp.calstatela.edu/idp:

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://idpp.calstatela.edu/idp:
             default: true

--- a/deployments/csulb/config/common.yaml
+++ b/deployments/csulb/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://its-shib.its.csulb.edu/idp/shibboleth:
             default: true

--- a/deployments/csulb/config/common.yaml
+++ b/deployments/csulb/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://its-shib.its.csulb.edu/idp/shibboleth:

--- a/deployments/csum/config/common.yaml
+++ b/deployments/csum/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://cma-shibboleth.csum.edu/idp/shibboleth:

--- a/deployments/csum/config/common.yaml
+++ b/deployments/csum/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://cma-shibboleth.csum.edu/idp/shibboleth:
             default: true

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://sso.csumb.edu/idp/shibboleth:
             default: true

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://sso.csumb.edu/idp/shibboleth:

--- a/deployments/csun/config/common.yaml
+++ b/deployments/csun/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           urn:mace:incommon:csun.edu:

--- a/deployments/csun/config/common.yaml
+++ b/deployments/csun/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           urn:mace:incommon:csun.edu:
             default: true

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://idp.csus.edu/idp/shibboleth:
             default: true

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://idp.csus.edu/idp/shibboleth:

--- a/deployments/csusj/config/common.yaml
+++ b/deployments/csusj/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://idp01.sjsu.edu/idp/shibboleth:

--- a/deployments/csusj/config/common.yaml
+++ b/deployments/csusj/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://idp01.sjsu.edu/idp/shibboleth:
             default: true

--- a/deployments/csusonoma/config/common.yaml
+++ b/deployments/csusonoma/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://login.sonoma.edu/shibboleth:

--- a/deployments/csusonoma/config/common.yaml
+++ b/deployments/csusonoma/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://login.sonoma.edu/shibboleth:
             default: true

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -29,6 +29,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
             default: true

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -29,6 +29,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           http://login.microsoftonline.com/common/oauth2/v2.0/authorize:

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           http://google.com/accounts/o8/id:
             default: true

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           http://google.com/accounts/o8/id:

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           https://idp.scccd.edu/idp/shibboleth:

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           https://idp.scccd.edu/idp/shibboleth:
             default: true

--- a/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
+++ b/deployments/template/{{cookiecutter.hub_name}}/config/common.yaml
@@ -34,6 +34,7 @@ jupyterhub:
         authenticator_class: {{cookiecutter.authenticator_class}}
       {{cookiecutter.authenticator_class_instance}}:
         {%- if cookiecutter.authenticator_class == "cilogon" %}
+        refresh_pre_spawn: false
         allowed_idps:
           {{cookiecutter.idp_url}}:
             default: true

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           urn:mace:incommon:ucsc.edu:
             default: true

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           urn:mace:incommon:ucsc.edu:

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        refresh_pre_spawn: false
         allowed_idps:
           urn:mace:incommon:usc.edu:
             default: true

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -30,6 +30,7 @@ jupyterhub:
       JupyterHub:
         authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
         refresh_pre_spawn: false
         allowed_idps:
           urn:mace:incommon:usc.edu:


### PR DESCRIPTION
this was causing errors when trying to use admin powers to become another user.

there is a related issue (that doesn't impact us) where github's api server was down last week and caused similar problems w/2i2c hubs.