### PR TITLE
update all `staging` hubs to use `DummyAuthenticator` and a shared password

### DIFF
--- a/deployments/chicostate/config/common.yaml
+++ b/deployments/chicostate/config/common.yaml
@@ -4,16 +4,16 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Chico
-          logo_url: https://www.csuchico.edu/_assets/images/brand/logomark-seal.jpg
-          url: https://www.csuchico.edu/
+  # custom:
+  #   homepage:
+  #     # gitRepoBranch: "username-and-password-homepage"
+  #     gitRepoBranch: "main"
+  #     gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+  #     templateVars:
+  #       org:
+  #         name: California State University, Chico
+  #         logo_url: https://www.csuchico.edu/_assets/images/brand/logomark-seal.jpg
+  #         url: https://www.csuchico.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -27,29 +27,29 @@ jupyterhub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
     config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://shibboleth.csuchico.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - rdonatello@csuchico.edu
+      # JupyterHub:
+      #   authenticator_class: cilogon
+      # CILogonOAuthenticator:
+      #   # temporarily disable token refresh to fix admin access to singleuser servers
+      #   refresh_pre_spawn: false
+      #   allowed_idps:
+      #     https://shibboleth.csuchico.edu/idp/shibboleth:
+      #       default: true
+      #       username_derivation:
+      #         username_claim: "email"
+      #       allow_all: true
+      #     http://google.com/accounts/o8/id:
+      #       username_derivation:
+      #         username_claim: "email"
+      # Authenticator:
+      #   manage_groups: false
+      #   admin_users:
+      #     # infrastructure
+      #     - jedwin321@berkeley.edu
+      #     - ericvd@berkeley.edu
+      #     - sean.smorris@berkeley.edu
+      #     - sknapp@berkeley.edu
+      #     - rdonatello@csuchico.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image

--- a/deployments/chicostate/config/common.yaml
+++ b/deployments/chicostate/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  # custom:
-  #   homepage:
-  #     # gitRepoBranch: "username-and-password-homepage"
-  #     gitRepoBranch: "main"
-  #     gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-  #     templateVars:
-  #       org:
-  #         name: California State University, Chico
-  #         logo_url: https://www.csuchico.edu/_assets/images/brand/logomark-seal.jpg
-  #         url: https://www.csuchico.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,30 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      # JupyterHub:
-      #   authenticator_class: cilogon
-      # CILogonOAuthenticator:
-      #   # temporarily disable token refresh to fix admin access to singleuser servers
-      #   refresh_pre_spawn: false
-      #   allowed_idps:
-      #     https://shibboleth.csuchico.edu/idp/shibboleth:
-      #       default: true
-      #       username_derivation:
-      #         username_claim: "email"
-      #       allow_all: true
-      #     http://google.com/accounts/o8/id:
-      #       username_derivation:
-      #         username_claim: "email"
-      # Authenticator:
-      #   manage_groups: false
-      #   admin_users:
-      #     # infrastructure
-      #     - jedwin321@berkeley.edu
-      #     - ericvd@berkeley.edu
-      #     - sean.smorris@berkeley.edu
-      #     - sknapp@berkeley.edu
-      #     - rdonatello@csuchico.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image

--- a/deployments/chicostate/config/prod.yaml
+++ b/deployments/chicostate/config/prod.yaml
@@ -4,6 +4,16 @@ nfsPVC:
 
 
 jupyterhub:
+  custom:
+    homepage:
+      # gitRepoBranch: "username-and-password-homepage"
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Chico
+          logo_url: https://www.csuchico.edu/_assets/images/brand/logomark-seal.jpg
+          url: https://www.csuchico.edu/
   ingress:
     enabled: true
     hosts:
@@ -18,8 +28,30 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://shibboleth.csuchico.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://chicostate.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - rdonatello@csuchico.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/chicostate/config/prod.yaml
+++ b/deployments/chicostate/config/prod.yaml
@@ -6,7 +6,6 @@ nfsPVC:
 jupyterhub:
   custom:
     homepage:
-      # gitRepoBranch: "username-and-password-homepage"
       gitRepoBranch: "main"
       gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
       templateVars:

--- a/deployments/chicostate/config/staging.yaml
+++ b/deployments/chicostate/config/staging.yaml
@@ -43,5 +43,4 @@ jupyterhub:
           - ericvd@berkeley.edu
           - sean.smorris@berkeley.edu
           - sean.smorris
-      # CILogonOAuthenticator:
-      #   oauth_callback_url: https://chicostate-staging.jupyter.cal-icor.org/hub/oauth_callback
+          - rdonatello@csuchico.edu

--- a/deployments/chicostate/config/staging.yaml
+++ b/deployments/chicostate/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Chico
+          logo_url: https://www.csuchico.edu/_assets/images/brand/logomark-seal.jpg
+          url: https://www.csuchico.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - chicostate-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://chicostate-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+      # CILogonOAuthenticator:
+      #   oauth_callback_url: https://chicostate-staging.jupyter.cal-icor.org/hub/oauth_callback

--- a/deployments/chicostate/secrets/staging.yaml
+++ b/deployments/chicostate/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:r7V5fsL9FhWCmrCOjuUMumZ280sT3LgOR3MR3tlNSkoJepvFWWw3b5v+QGHAdXPmoMTa,iv:fA7KREeubYqZ37u44x2fVKunLwEFke0HL9YCRM9eZSw=,tag:vzB3uNO6VOAFwcZDG68KUQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:hn9dOn6WJBZnWnfKK+wdIf0ZaTHNZqloWUma3K/wmqxWzyU6cCLkZts0z74LNm2qAVl/TcVENuVyEwXNnG48c1dmFfVpM9b+/TuOdb6pncXFFMpZLwY=,iv:Sj6cOUJi34JEYSEQNEcpX6J+0g/PJwFkP1fiGNW+Uak=,tag:UoaEZETPSaFWbDPqLOQDRw==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-11-08T18:48:56Z"
-          enc: CiQA471gamwyx9YmQGsStUNp9cn3EbSze6KcLZ/2M2cPZCZN7e8SSQBxTImx7lRn3byuMdp9/Jr0od/Y5HwPeVPah+2ypOwqjvVX+BfNb+LscTkTFE76uB3hjv4Vnnlxzgwn15v0cz5eyaShlEVLYxI=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-11-08T18:48:57Z"
-    mac: ENC[AES256_GCM,data:1OMjVOZti3NvkIYTClvxg3xzMio48iiqcJdjYuknphIt2h+j1HARgETiqTUR9ThMgd8vBYc9OVREK51ZWoy6pgMVRz8IBRUOkDkBO8Ga6PWPxvrI1qo0iFx1DwUrQzprGOHTpWaqzQs5viak4+fk0pxIRgdJI+Bkm6+Hfo5XJIU=,iv:FvFuvKIB5CQq68cB5JmuJhAjhu1Yfl22L3MQAPLu/SY=,tag:p5AfuCbSGf/NVT50PhEvzg==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csub/config/common.yaml
+++ b/deployments/csub/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Bakersfield
-          logo_url: https://www.csub.edu/brand/_images/brand-primary-logo.jpg
-          url: https://www.csub.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,30 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://shib.csub.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - ayatawara@csub.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csub/config/prod.yaml
+++ b/deployments/csub/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csub/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Bakersfield
+          logo_url: https://www.csub.edu/brand/_images/brand-primary-logo.jpg
+          url: https://www.csub.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,30 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://shib.csub.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csub.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - ayatawara@csub.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csub/config/staging.yaml
+++ b/deployments/csub/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Bakersfield
+          logo_url: https://www.csub.edu/brand/_images/brand-primary-logo.jpg
+          url: https://www.csub.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,17 @@ jupyterhub:
           - csub-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csub-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - ayatawara@csub.edu

--- a/deployments/csub/secrets/staging.yaml
+++ b/deployments/csub/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:VE8B/03v/fWSPzDHIdVok3qYqjl9m2dEFsOX2Lagi10DJwIsfgzUfc9DcHN7tiOfsCSv,iv:Uth+Ge5Uf4+iFYTFFVRt6Mf4AoRWcHbqM3vTKaQeMCU=,tag:GEkWvv4gkMvoPTDU33LYeQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:2FAQIWTVCwPII5UDsTPmmKVzEgwOF9XS5/M24HVHAY+RYoLeNxGonK5NcBbSD5uXGeJwE3n02F1iGH/Eh26W0+iXVmiaEhZniztx2Mc2DJIJ+qJ3EXs=,iv:/ihiYC9wBmR+5rYr+D27kRNthSFWRXxM40N1+GUS1K0=,tag:oPTlBzVdBso6FM98DccH5A==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-23T23:49:10Z"
-          enc: CiQA471gar10rEESg/TVP9NGSzr5TE4ud/BfFiO2cgmf76ZO+/gSSQA0woZQXJ8+Uai9ZdU81hNadSrIqS7INnNnB3Yw9fLVlXGZ7cRFYekPbA18o4TlZvZPtryRJaSNNy7tMEi13P4WRmkPiR9Jvqs=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-23T23:49:10Z"
-    mac: ENC[AES256_GCM,data:jZymtLLITMV4K4IypgmfBIdmoNhJK/y3hKU2rV2tAj4kQAxOcCa1G7fr0al2d8ViQGUhS0jecUGyTB7ttYLIeQqiaDdjAy86BZBIstw4fpXSZNgBv1B0ZSorjuChwDWl2SwsxTXAjAeVJZ/XcffU+vm8/Y+xtalqnkkteh84zfc=,iv:1LxaJiY2QnRbML+YP1Ryg/0609L15RQfCzGpQ18D4Go=,tag:mYmny5lIdR2ArAhyPJgXKw==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csueb/config/common.yaml
+++ b/deployments/csueb/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, East Bay
-          logo_url: https://www.csueastbay.edu/_global/images/footer/new-csueb-logo/vp2-logo.png
-          url: https://www.csueastbay.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,31 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://vince.csueastbay.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - mary.combs@csueastbay.edu
-          - mikahl.banwarthkuhn@csueastbay.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image

--- a/deployments/csueb/config/prod.yaml
+++ b/deployments/csueb/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csueb/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, East Bay
+          logo_url: https://www.csueastbay.edu/_global/images/footer/new-csueb-logo/vp2-logo.png
+          url: https://www.csueastbay.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,31 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://vince.csueastbay.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csueb.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - mary.combs@csueastbay.edu
+          - mikahl.banwarthkuhn@csueastbay.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csueb/config/staging.yaml
+++ b/deployments/csueb/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, East Bay
+          logo_url: https://www.csueastbay.edu/_global/images/footer/new-csueb-logo/vp2-logo.png
+          url: https://www.csueastbay.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - csueb-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csueb-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - mary.combs@csueastbay.edu
+          - mikahl.banwarthkuhn@csueastbay.edu

--- a/deployments/csueb/secrets/staging.yaml
+++ b/deployments/csueb/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:4MalixzqktwODIGWMruKUYMWmFP1EsorqHApSywy2FFEm2PT8VZqT/zsFOo0ULvKHPY=,iv:GYVq/7RdVIyvKF1doqi1x+EO2QfMUaB6dHae+dub+M8=,tag:TyNS9Lt8ztxq7qFEXGrI0A==,type:str]
-                client_secret: ENC[AES256_GCM,data:vlmV7YIQnGegJGm1rbPk61FPZKm4gu/oby0gDssSWgY5SV34MdlsqsSSYwpG9WWabXP2L0GEsruoR3JvekhLUbY82MwfEhUqV4tqtJa8gplmqK/KzCw=,iv:Qs5d5dFyj6KkOWM2/mbyyETYdIah3eNSMp0GcpINHgk=,tag:mI8Wgtl22/zE9WjZsw37Tw==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-09T21:41:20Z"
-          enc: CiQA471gamM946ssQIc7W00sk4/VltOuNL/5BebS/eIdxqBwaqcSSQA0woZQOE4jBKtlQ8Q9IGfHrq1GqevHCgqiKAcKrub8jkNdzM+41eYXAQnvcsI/AMAr5PqvHmZ3cUIqM4vsOyU7pa9R/DlSyt4=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-09T21:41:21Z"
-    mac: ENC[AES256_GCM,data:pjPoBuUef4joN9fyLWTtBCQHwWePg8MJqgds5ycXTSKSyMsBIvqIPbW+bru2fm/IiilZoFsiVWFjjEe+Ptmsya0mDXU8iPnieYK823Q6a0iL+J49wURS+uwHFcN6Xsu7VfKnJn0rZcPFX66pWqwvOTuekcOy3fJMuplZ/Y6eCns=,iv:DnpeniD2y93guzvdIy8um2v45dIUivYeWkxREEq3r6o=,tag:bua1mWVCDdQqZfnPFJw/ig==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csuf/config/common.yaml
+++ b/deployments/csuf/config/common.yaml
@@ -4,14 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "csuf-specific"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Fullerton
   scheduling:
     userScheduler:
       nodeSelector:
@@ -24,32 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://shibboleth.fullerton.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - jjaynes@fullerton.edu
-          - wpeng@fullerton.edu
-          - dchandswang@fullerton.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csuf/config/prod.yaml
+++ b/deployments/csuf/config/prod.yaml
@@ -3,6 +3,13 @@ nfsPVC:
     shareName: csuf/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Fullerton
   ingress:
     enabled: true
     hosts:
@@ -17,8 +24,32 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://shibboleth.fullerton.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csuf.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - jjaynes@fullerton.edu
+          - wpeng@fullerton.edu
+          - dchandswang@fullerton.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csuf/config/staging.yaml
+++ b/deployments/csuf/config/staging.yaml
@@ -5,6 +5,13 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Fullerton
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +28,19 @@ jupyterhub:
           - csuf-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csuf-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - jjaynes@fullerton.edu
+          - wpeng@fullerton.edu
+          - dchandswang@fullerton.edu

--- a/deployments/csuf/secrets/staging.yaml
+++ b/deployments/csuf/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:wgpASQGfyljT4mmd7DbdtP1XtR6A903N7zcWk+5KWPgIg4G+9tNqbJ8kFjKbRQb7kpE=,iv:bVwpLIbBdHdSXn8H4BrTRKVCjPK8QIvf6z6tEmWinSI=,tag:ZdanspVsG0Btu6zQsVWMAw==,type:str]
-                client_secret: ENC[AES256_GCM,data:kZPt83/Pum/km4cEn37kLytqqxkmfDI1wEQg5ulCHSeb70N/2/UrpldnzoSNn4HanxTqtuABn6zOcq1gkkxuBLwKieOZX6YAHSylElJiG5TLixyp2Js=,iv:0+kwws9f7JYnwxzO0AVjeQWJ0/hwBA8426pIkmoGIhY=,tag:cROTinCcskgeqWHwI3hs0Q==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-05-27T23:54:24Z"
-          enc: CiQA471gag8QAePJM2f/pbSPP5un6XQCSxoebBvgv9JoW62IOoASSQA0woZQYMruewuVawL9YOKZiqX5WTPYvvVyDIFpTum3oXTWvHHybyaXh8THmNJsbxZW02UKSQEVpKJU3E7RNEmFntX5d/Z1T1I=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-05-27T23:54:24Z"
-    mac: ENC[AES256_GCM,data:206KxVIHW5io2ROAMaYcYrqVtId2EtnJkSt2msB4Af+kOaEeYroHiJ0MX0G15xUCVb/OcARGER6icSUeeceszOBqyedAtgeTRt03TCALdtatHzuHfsWwNyoYM8EBrdh+JXdDWVijKfjrJA+cXLEckGcF/72rpHVOkGAKGEud4q4=,iv:SyfaOkkSLVxSd0pZiZLP/1+ckIXYKDa2mQdRq8kZ5tQ=,tag:Mhf0jMDj4PUCoPrn5d3Gow==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csufresno/config/common.yaml
+++ b/deployments/csufresno/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Fresno
-          logo_url: https://marcomm.fresnostate.edu/images/fs-logo-color-stacked.jpg
-          url: https://www.fresnostate.edu/index.html
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,31 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://shib-idp.its.csufresno.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - earvin@csufresno.edu
-          - ytanai@csufresno.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csufresno/config/prod.yaml
+++ b/deployments/csufresno/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csufresno/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Fresno
+          logo_url: https://marcomm.fresnostate.edu/images/fs-logo-color-stacked.jpg
+          url: https://www.fresnostate.edu/index.html
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,31 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://shib-idp.its.csufresno.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csufresno.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - earvin@csufresno.edu
+          - ytanai@csufresno.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csufresno/config/staging.yaml
+++ b/deployments/csufresno/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Fresno
+          logo_url: https://marcomm.fresnostate.edu/images/fs-logo-color-stacked.jpg
+          url: https://www.fresnostate.edu/index.html
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - csufresno-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csufresno-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - earvin@csufresno.edu
+          - ytanai@csufresno.edu

--- a/deployments/csufresno/secrets/staging.yaml
+++ b/deployments/csufresno/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:rlFurV/JwnUYRh4ZTKFrg6Ja+PRz6SlJZcNuquFxPw96vjljEJDLsonZFfH72vWOmN3t,iv:R2S/8/LK6YpHx0i3q0Vth/c+kNVZcaHSFQmMk1HpWo0=,tag:7wMW19zuzK+aCYSdhPGeYA==,type:str]
-                client_secret: ENC[AES256_GCM,data:r4/kaSuh/wJq32o9K0/1wWh2YK9zsOAelJb05qzFLbEKVJA8SRXCBqUF5nY694YlYcijMY5CtErpylcUhM/RBMhvRo7iGGCdo+2rFA1E7/wRJi0zzBI=,iv:LKW7nHrwQobocGl0hZZJOZTI2z+Mem9CNzv/uTDskz4=,tag:6RRE6ux6WxAyqSPcNZielA==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-09-11T00:02:38Z"
-          enc: CiQA471gaqVfuSG3RHgaKS7LlAGIYbGSYydwYsL5JAsEK5cPERYSSQAC0RWo4N1dlCm/RRsoa8Kr5jlcf/sZ9WKlro9vtlvyNNrm1L6h8GOWR6aNyNtbNCo/s49mWUFH/8XXYbk4YTBbXL1/EADK9vE=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-09-11T00:02:39Z"
-    mac: ENC[AES256_GCM,data:Qoq7vEw+1HYcs2o3ZLdrxGAw1f+z086UrEmbt8lvLKHxPv4NXrg9do6Y35CiQxd6BXVvP/KbXQmrRrRZFTf8dJ0tdLvz4tkxLA3rAQylsuxkFqLNwlg66UBeE9lhRhqSEUZ0NdNLgHup4T9WA9VernDGBKgFi7Lxt2GYsYot0Sk=,iv:gAudfw4Uk4BdPXCkn5mzs/Fm3thpVf7tZ9MqZoflLRE=,tag:GBGlVsC+atCfNLUhvSIGIQ==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csula/config/common.yaml
+++ b/deployments/csula/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Los Angeles
-          logo_url: https://news.calstatela.edu/wp-content/uploads/2025/05/placeholder.jpg
-          url: https://www.calstatela.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,35 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://idpp.calstatela.edu/idp:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          https://idp.csudh.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - json2@calstatela.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csula/config/prod.yaml
+++ b/deployments/csula/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csula/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Los Angeles
+          logo_url: https://news.calstatela.edu/wp-content/uploads/2025/05/placeholder.jpg
+          url: https://www.calstatela.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,35 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://idpp.calstatela.edu/idp:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          https://idp.csudh.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csula.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - json2@calstatela.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csula/config/staging.yaml
+++ b/deployments/csula/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Los Angeles
+          logo_url: https://news.calstatela.edu/wp-content/uploads/2025/05/placeholder.jpg
+          url: https://www.calstatela.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,17 @@ jupyterhub:
           - csula-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csula-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - json2@calstatela.edu

--- a/deployments/csula/secrets/staging.yaml
+++ b/deployments/csula/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:qMISQvtaqI7bcvPTqb4GAxZ8NB4wuziw5QCDCjEbox85S6hOtU97svn02yzTkzSrVfo=,iv:GS3tAcdfcrSY9YQD1+mKpLPhC9cwrf32nfDFxSZt0rk=,tag:YsGrV2XD6ExtpQwifxx5aQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:99wnezVPpmoNoJzrWFoKeHiyvyD3I2pk+Ci1waH/MqHPunXXjAY90sRS9AEt3kLqQqIJCfyID36AopmsLuHCl+/ClF6Fx5AyNLWupSI6eM4C7RdW6Eg=,iv:1OZ0OSZr1DelzvyHd4ANl8hgkrpEqgY5DwRSYx8OYjM=,tag:G2gWxDTGu7aRCA64StKLtg==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-09T22:12:53Z"
-          enc: CiQA471gap1khBFtiM/36B7by9gP+l9+hY6Fm0oa49MhgD+b4cwSSQA0woZQYjO/ywPK+Q7ahY9cEiEP3FH5KV0ck+/VjK60r6naQzdnF+wPQcBffEplLEDzZmaWqcAsLTPwUBB0fFA2poGawS+VLKo=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-09T22:12:53Z"
-    mac: ENC[AES256_GCM,data:Thp5lDNFPxe/CTdLrL+b6YIqfDOPTjCYLKsDnyAl1iJ0fG/5L1Q14fsWJiayzjVuUMmskdb9TgJUW2GurQZXvG9N0KDE6ScBTR5i4NZGMXk/82qe8pZeaBiweWOlo3jjPEZFXYsoHyC6JIOEX8Uv7WzxYnvt8tJrm20s/dT8YWM=,iv:3v+E5IrcZLedA3Tykq737fqZjHIdEPIp0cJUwQJsSjQ=,tag:uHQuSVDtI9b6jE+xt9zJOg==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csulb/config/common.yaml
+++ b/deployments/csulb/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Long Beach
-          logo_url: https://www.csulb.edu/themes/custom/csulb/images/logo.png
-          url: https://www.csulb.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,41 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://its-shib.its.csulb.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - csulb.edu
-              - student.csulb.edu
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - shabnam.sodagari@csulb.edu
-          - Kagba.Suaray@csulb.edu
-          - Tianni.Zhou@csulb.edu
-          - Antonio.Martinez@csulb.edu
-          - Babette.Benken@csulb.edu
-          - Florence.Newberger@csulb.edu
-          - Seungjoon.Lee@csulb.edu
-          - tyler.nakamura@csulb.edu
-          - Rebecca.Le@csulb.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csulb/config/prod.yaml
+++ b/deployments/csulb/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csulb/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Long Beach
+          logo_url: https://www.csulb.edu/themes/custom/csulb/images/logo.png
+          url: https://www.csulb.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,41 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://its-shib.its.csulb.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - csulb.edu
+              - student.csulb.edu
         oauth_callback_url: https://csulb.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - shabnam.sodagari@csulb.edu
+          - Kagba.Suaray@csulb.edu
+          - Tianni.Zhou@csulb.edu
+          - Antonio.Martinez@csulb.edu
+          - Babette.Benken@csulb.edu
+          - Florence.Newberger@csulb.edu
+          - Seungjoon.Lee@csulb.edu
+          - tyler.nakamura@csulb.edu
+          - Rebecca.Le@csulb.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csulb/config/staging.yaml
+++ b/deployments/csulb/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Long Beach
+          logo_url: https://www.csulb.edu/themes/custom/csulb/images/logo.png
+          url: https://www.csulb.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,25 @@ jupyterhub:
           - csulb-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csulb-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - shabnam.sodagari@csulb.edu
+          - Kagba.Suaray@csulb.edu
+          - Tianni.Zhou@csulb.edu
+          - Antonio.Martinez@csulb.edu
+          - Babette.Benken@csulb.edu
+          - Florence.Newberger@csulb.edu
+          - Seungjoon.Lee@csulb.edu
+          - tyler.nakamura@csulb.edu
+          - Rebecca.Le@csulb.edu

--- a/deployments/csulb/secrets/staging.yaml
+++ b/deployments/csulb/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:V70Wb0w7/svaykOLdhR73feSFs0QPMNS10Tfven95Eke9OtNoPTzGw18J4Z5GfjpJdnO,iv:zrhk3KyYpDCLR6btTWv0absq+sNu8JzBu1LDNxl0e3o=,tag:D/ZOfEATPYfeAl33rHxikQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:6mmQ80M7Ga5XbeW2cFJybQ7qqgEXWEe4bpcmpyEi/glqyEwuKP/oEAyIaLPog7jfMW4c6XkrbHjC46lpsqmoz9E+qkrmrUn6MMrpU9A6InwHfEQBOCc=,iv:Es53Au935BO3P5Jl420JQVm+zlGCRexYZ6g4KJCQxFY=,tag:QE6zaaTOhfA18t/+bQhitg==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-05-28T00:28:46Z"
-          enc: CiQA471gankf3fuDtdl3u2k1pfsRZE0vs7T5tPiLI3XC9qyVT+wSSQA0woZQirolAGaBjO3CpZCNMOthfIC9mTi3bXzRauAhYUIdcFbCCalqQupg8wQowPVn6BQFQGitB2TlYiHcU3bcM7jlQb0I3Do=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-05-28T00:28:46Z"
-    mac: ENC[AES256_GCM,data:f8jwdaNpiG2300u4lPYCYGAQIpLDJyrrBbu03G1G0+Zf0xwGR/8pEgQfbg8UWR4egWyoneZFOaBKI3st3+2lt8qe+wXT9Z/f9AIZsjaca/BrKKlPjclC+wT4X5MnZabTMHPseTvESOidWq6TrwSfSxXUClLj48cCNOJ7DA/GCPY=,iv:a1DYn4VHfHWvUk8IOWY9KDw6ouLb0PgX7jvGv6PpVb4=,tag:WZCStihiZrRErOMwy9t03Q==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csum/config/common.yaml
+++ b/deployments/csum/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Maritime Academy
-          logo_url: https://maritime-archive.calpoly.edu/_resources/images/cal-maritime-logo.svg
-          url: https://www.csum.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,31 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://cma-shibboleth.csum.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - jteoh@csum.edu
-          - tinoue@csum.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csum/config/prod.yaml
+++ b/deployments/csum/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csum/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Maritime Academy
+          logo_url: https://maritime-archive.calpoly.edu/_resources/images/cal-maritime-logo.svg
+          url: https://www.csum.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,31 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://cma-shibboleth.csum.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csum.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - jteoh@csum.edu
+          - tinoue@csum.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csum/config/staging.yaml
+++ b/deployments/csum/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Maritime Academy
+          logo_url: https://maritime-archive.calpoly.edu/_resources/images/cal-maritime-logo.svg
+          url: https://www.csum.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - csum-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csum-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - jteoh@csum.edu
+          - tinoue@csum.edu

--- a/deployments/csum/secrets/staging.yaml
+++ b/deployments/csum/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:B7Fvu112eCy91jFPhABp9QH/oAcMUfPrMpJcFedhu5pVWCaUNqB/y4w3w1iLfjD8c3ho,iv:5Db/9xqT2iDiHFbEVIcpQ7KoJkSVBWTj24ASzQcGDtE=,tag:B5v6Xiigm9900wj3mFufNA==,type:str]
-                client_secret: ENC[AES256_GCM,data:m7ijknwiGFKPnr0WTxymbr2+pcmoaHEVFBdRbr6trMjSH3PPRD+UNfyck/0Nq6QbMTYE1RfIMX8QH+4nHGAGlY1obnVxBYDcBnVT45oQ/qzq5/GlRiA=,iv:a2torvwaqE70t5g93AcuJKtJDXBXowZwW5Wy/fbdSa4=,tag:VE+4cmIbiXbDNdVXfChAsQ==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-05-28T00:10:45Z"
-          enc: CiQA471gaj9fbGs3zN/bZnc+1ilFFSbRwVs3UOU0vlhvQO3vao4SSQA0woZQd+AX4u6wgqIcar2gCmFOySvl9f70gCl4mz4LwPSr8D6vrqf3bwpmwjQoJ+5MN2aBU2I9EkQjChAiLgswA8eBEXYdRq0=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-05-28T00:10:45Z"
-    mac: ENC[AES256_GCM,data:BukliTRvl++B+C9FrFDDVBxtKnc3ZPxfwSWs2n52wPyuQ3ZhG9zw8ipJx19mAxfT8sxGbc0sk9iMZyzkLY4yjEZCtZt8fO6Bfa5IDs5UvXM0N4GUaSTgftXikgkCItoKRncEs/GcdjJ4I2wn+oe1RDLXJjcsREnFdMEx/PyP6Uo=,iv:1RR/v6CzHofSZ9OKd85MjB8zfkM1YcWVPj5On0jtfk0=,tag:CQpTGbWvoE5RLaa2/IB/kg==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csumb/config/common.yaml
+++ b/deployments/csumb/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Monterey Bay
-          logo_url: https://csumb.edu/media/csumb/site-assets-2024/images/logo.svg
-          url: https://www.csumb.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,45 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://sso.csumb.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - aunfried@csumb.edu
-          - clogan@csumb.edu
-          - ducampbell@csumb.edu
-          - etang@csumb.edu
-          - hglanz@csumb.edu 
-          - hswift@csumb.edu
-          - javmata@csumb.edu
-          - jcanner@csumb.edu
-          - jguilinger@csumb.edu
-          - jmccall@csumb.edu     
-          - njue@csumb.edu
-          - pshereen@csumb.edu
-          - sajorgensen@csumb.edu
-          - shereynolds@csumb.edu
-          - sogden@csumb.edu
-          - stkim@csumb.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image

--- a/deployments/csumb/config/prod.yaml
+++ b/deployments/csumb/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csumb/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Monterey Bay
+          logo_url: https://csumb.edu/media/csumb/site-assets-2024/images/logo.svg
+          url: https://www.csumb.edu/
   # singleuser:
   #   image:
   #     name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
@@ -21,8 +30,45 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://sso.csumb.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csumb.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - aunfried@csumb.edu
+          - clogan@csumb.edu
+          - ducampbell@csumb.edu
+          - etang@csumb.edu
+          - hglanz@csumb.edu
+          - hswift@csumb.edu
+          - javmata@csumb.edu
+          - jcanner@csumb.edu
+          - jguilinger@csumb.edu
+          - jmccall@csumb.edu
+          - njue@csumb.edu
+          - pshereen@csumb.edu
+          - sajorgensen@csumb.edu
+          - shereynolds@csumb.edu
+          - sogden@csumb.edu
+          - stkim@csumb.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csumb/config/staging.yaml
+++ b/deployments/csumb/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Monterey Bay
+          logo_url: https://csumb.edu/media/csumb/site-assets-2024/images/logo.svg
+          url: https://www.csumb.edu/
   # singleuser:
   #   image:
   #     name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image
@@ -25,5 +34,32 @@ jupyterhub:
           - csumb-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csumb-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - aunfried@csumb.edu
+          - clogan@csumb.edu
+          - ducampbell@csumb.edu
+          - etang@csumb.edu
+          - hglanz@csumb.edu
+          - hswift@csumb.edu
+          - javmata@csumb.edu
+          - jcanner@csumb.edu
+          - jguilinger@csumb.edu
+          - jmccall@csumb.edu
+          - njue@csumb.edu
+          - pshereen@csumb.edu
+          - sajorgensen@csumb.edu
+          - shereynolds@csumb.edu
+          - sogden@csumb.edu
+          - stkim@csumb.edu

--- a/deployments/csumb/secrets/staging.yaml
+++ b/deployments/csumb/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:RllvHvzcwzGf1qLP5f3q8f5SlpEPBYwCOMcAmTVqBoOERMiHNZkZjoGhE26JLQN/d0Nv,iv:qUeY+xT0EBDpcan1cgSXKtRg1hTKb2tsIRL03toZLp8=,tag:sNWr1uFIgf5tZMIoRQF26w==,type:str]
-                client_secret: ENC[AES256_GCM,data:aPYhw2WqA2ttsTjoW/AEUs0yOrDTfikLmspAj5QLdfcKfKHpJauTFQRT06s00ZY8TJzvetku65HZzkcRatKkz3jZUlrzr9gs7aGSzNagQCJvBqygvng=,iv:Hb5rN+1ZHwHe/Wb/BiDIpZRGya+Oa+UBFqJDMCgkbSY=,tag:NO2eSTSqZTObCcZv7P00oA==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-09T22:03:28Z"
-          enc: CiQA471gamV2uRA+Ohc87k15/w5Z3cCvCuvXyI2W51gsmNTAT4gSSQA0woZQZijKm69aiasdI1JI8iWMnRXdJQYnZb5h84eNvOyc1RKVxuPPwXhT0two7PL8hTyOQ+mYO7eFhte++p3K3q4TGCyDDp8=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-09T22:03:28Z"
-    mac: ENC[AES256_GCM,data:mvGxN8PEUpPflEdLauhf1MgwUaia+vmYAk1rkgtCmaFM5I80HBqru3iZDwIu3YcR3HJf1lmpcKfEFk1Aj1c9qWMrjdhHLOQlHyIe/z+4uIPELHxBmhCHUWD58WlA4awJiZsYO1dPDpuP1E5TTFcLiYKD0/Oc8guE05jV6AhHVNg=,iv:8yeYOIC9e6JQq5J7ypWmEuYlcodLcDkQiwpIgtYYbYE=,tag:3igIw3vq7B6Sj+e+eHVjOA==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csun/config/common.yaml
+++ b/deployments/csun/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Northridge
-          logo_url: https://upload.wikimedia.org/wikipedia/en/8/8c/CSUNS.svg
-          url: https://www.csun.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,30 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          urn:mace:incommon:csun.edu:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - wayne.smith@csun.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csun/config/prod.yaml
+++ b/deployments/csun/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csun/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Northridge
+          logo_url: https://upload.wikimedia.org/wikipedia/en/8/8c/CSUNS.svg
+          url: https://www.csun.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,30 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          urn:mace:incommon:csun.edu:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csun.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - wayne.smith@csun.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csun/config/staging.yaml
+++ b/deployments/csun/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Northridge
+          logo_url: https://upload.wikimedia.org/wikipedia/en/8/8c/CSUNS.svg
+          url: https://www.csun.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,17 @@ jupyterhub:
           - csun-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csun-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - wayne.smith@csun.edu

--- a/deployments/csun/secrets/staging.yaml
+++ b/deployments/csun/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:R4Ekq0euSbzcJj9prXpKT2qP7Hqb0S8JX8I7TVfbzJx4mETRztx6oDh+C50tA5VaprmV,iv:P0HRbFbOIzxc+HgW/RpRCwDRnE+Hbv40qs04ZctuGbc=,tag:JGtITiQ5pG8c6/fX7/Efog==,type:str]
-                client_secret: ENC[AES256_GCM,data:OWKHeK3Pyi3b1z5z1KQFv57ZcHwW/M+USLrz+aa99NsbsBTSfNy0THn/nCzUonVa3/lGpU2nSbwxg6k6JsgtcXm0uzO8RU6RMKcMm1YUV2teR/gpdpI=,iv:6goMVSVMWYf96B6XbvLk3CNPHR/9d73cWPIP6TRr6P4=,tag:XnTegjaB7KrwVr6KB1xGVg==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-10-09T22:28:16Z"
-          enc: CiQA471gaovJ7XHvp4M0va6RSavKEC1un4ejP/6cR3rXZCr2pXQSSQAC0RWolpJkw7kJRo1S7t/oDbAccuwIlLEOtarbSb+l7VlE4boS93rnSrDxd9Qz5jQ1RYtbXC/3fElqfckZEToFzSlw4f4nF24=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-10-09T22:28:16Z"
-    mac: ENC[AES256_GCM,data:OzfGq/jBECOk0iVqDMYr2c+Wvzl3lvvq9t4vXtFG2EWPaUj/9lKE6OJJBJg715oo7zU/mVL29y2ph2AtGSvmSOJX18Oki7sGAZ1wAircaJs8TITKRw6kvIjCRUWr/1miXaSZ/IcMjyKDioEnwlfKBE/qEJFC8I5PKAmcvJWOpbg=,iv:dz/aBR8DFofMmw/U694mvefsUNx9N5J0u+G+habZuWA=,tag:JhJFhBxIrWw5hioYABAW8A==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csus/config/common.yaml
+++ b/deployments/csus/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Sacramento
-          logo_url: https://www.csus.edu/NewCSUS2019-global-assets/_internal/images/logo-horizontal.png
-          url: https://www.csus.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,31 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://idp.csus.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - fitzgerald@csus.edu
-          - norris@csus.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/csumb-user-image

--- a/deployments/csus/config/prod.yaml
+++ b/deployments/csus/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csus/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Sacramento
+          logo_url: https://www.csus.edu/NewCSUS2019-global-assets/_internal/images/logo-horizontal.png
+          url: https://www.csus.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,31 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://idp.csus.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csus.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - fitzgerald@csus.edu
+          - norris@csus.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csus/config/staging.yaml
+++ b/deployments/csus/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Sacramento
+          logo_url: https://www.csus.edu/NewCSUS2019-global-assets/_internal/images/logo-horizontal.png
+          url: https://www.csus.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - csus-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csus-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - fitzgerald@csus.edu
+          - norris@csus.edu

--- a/deployments/csus/secrets/staging.yaml
+++ b/deployments/csus/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:UvtqsjGQ1aReoyy8ViFfe6EWQdFCgsXgnT8SyzblBJ2C0qf+0ivRQQjlVQ9cqudUIMVU,iv:EgUAJAmoprhLsqaJA8DG35nwlBQhyQZTP9TfdmkbSVE=,tag:WNWnfLuyLCF8Ff5K1kf92g==,type:str]
-                client_secret: ENC[AES256_GCM,data:pqo7CNuB/K+WlbRVMD/I6+bA1HgNGffwBKl/Jh4zDj5RTVUjOs9cLHTNXn5v/OlrzCX2OqiCP/XQwklfTdcPR+T9QO3xcU4KlP+ohpd+Th27VMt09CA=,iv:MNXblxmIYynl0W5rjUyFi6JVNMGeZn9a2ReqE1Ei3Jw=,tag:esRH1RYMXEBvSW5MakVeCQ==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-09T22:06:12Z"
-          enc: CiQA471gatf6D9fp4f0rdT1p/KgmK7aZZVYso1mzyS0SbL24l6USSQA0woZQyLWn+IJWaX27vBq+BlI5aUu5EjIOZQzDnwTbag+vJDqm4/63AOzHY38x1o17p/gd7f8n4VRfrfkexORqZXgrA5rFxGI=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-09T22:06:12Z"
-    mac: ENC[AES256_GCM,data:eBilgizyTbIHrSS71XfM7nmDk847hVTp22XvGWdiA9JNxJwJYPFOSZrDaE8CFqXpqBwdhQR09b7X4WtK7tPWYopUnYOgnYLh5saGigeiUuzAf4i0dNjlAkBGE0OBKULcxn64qvugoMlu93FntkJXDHU5EFc7w1RGKLtesEHjW1I=,iv:ULEpVYCm1L9gK2uyL42Grf64Pawr7G9DhlCZ6ASzCDw=,tag:8CF+L4R1GspkFCdoBTwCXw==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csusj/config/common.yaml
+++ b/deployments/csusj/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, San Jose
-          logo_url: https://www.sjsu.edu/aspis/media/brand/icon-spartan-withbackground.svg
-          url: https://www.sjsu.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,30 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://idp01.sjsu.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - rula.khayrallah@sjsu.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csusj/config/prod.yaml
+++ b/deployments/csusj/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csusj/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, San Jose
+          logo_url: https://www.sjsu.edu/aspis/media/brand/icon-spartan-withbackground.svg
+          url: https://www.sjsu.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,30 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://idp01.sjsu.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csusj.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - rula.khayrallah@sjsu.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csusj/config/staging.yaml
+++ b/deployments/csusj/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, San Jose
+          logo_url: https://www.sjsu.edu/aspis/media/brand/icon-spartan-withbackground.svg
+          url: https://www.sjsu.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,17 @@ jupyterhub:
           - csusj-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csusj-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - rula.khayrallah@sjsu.edu

--- a/deployments/csusj/secrets/staging.yaml
+++ b/deployments/csusj/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:0+378GpG6PC4g++wgfYjLl4FJ/4bH3J1Ma6uolMBcCKyE+Lmyl2uNoRbkQkM9sscV/Xx,iv:UkqWWxh2xJ5WKh4Qc5wAmG9n+okZkjb9K64cqxU3JyM=,tag:PaHcGATCq0XTDmx578zPgw==,type:str]
-                client_secret: ENC[AES256_GCM,data:ML9CSPuu5mFLzhJDaJN64jTV0/TfQPZ41l+mDrPWLhL2iXhW46Tk2zk5qZG8K22bIJAsw/pXaVVfq4Y12MejyuVVkLZJnHEg28whSz0jgWufQoJUP5o=,iv:NP8zVKHWagKatcryMyRGSuY14Qn6BQ2fd1QVYe2wVNA=,tag:x5VQ0H6LD6OWE9xyo9aSnQ==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-09T22:15:20Z"
-          enc: CiQA471gaq/Iw7c+cvWkzhPKZdALyaahALTiYQV1U9CBenGrlBESSQA0woZQrHbkoJyXHMIiVBTKW1UWzoVOAu/1yemdZX0e4xInAp/6YLh3lYIew1Q/4oFnY6zhuSwxfBmjF9zL65FjC8gBNp4e47U=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-09T22:15:20Z"
-    mac: ENC[AES256_GCM,data:WLAkfAL+O9pXr36wCmO7ZFAJZt9XCyPs8g2preBitOdEQPHUr343CqnS7zSWDGGq1s1/XeyP2Oml5k9h8yOvxf2A3tAuf9IfNPYfSAFGTnnG1QePRWbqC1GAvDzrdoALsBcyt328NMsNqe4713Ct2vjx1SJlH8Zzlq83Rye1xDo=,iv:SKKzFGvI+1ODSbsLvHppktP+t0LLxo/cXarO+EZ96Pg=,tag:B00e705R1CwgJJrw7o4y1g==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/csusonoma/config/common.yaml
+++ b/deployments/csusonoma/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: California State University, Sonoma
-          logo_url: https://admissions.sonoma.edu/themes/custom/ssu_radix/build/assets/images/ssu-logo-full-left-blue.svg
-          url: https://www.sonoma.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,30 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://login.sonoma.edu/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - ortegao@sonoma.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/csusonoma/config/prod.yaml
+++ b/deployments/csusonoma/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: csusonoma/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Sonoma
+          logo_url: https://admissions.sonoma.edu/themes/custom/ssu_radix/build/assets/images/ssu-logo-full-left-blue.svg
+          url: https://www.sonoma.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,30 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://login.sonoma.edu/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://csusonoma.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - ortegao@sonoma.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/csusonoma/config/staging.yaml
+++ b/deployments/csusonoma/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: California State University, Sonoma
+          logo_url: https://admissions.sonoma.edu/themes/custom/ssu_radix/build/assets/images/ssu-logo-full-left-blue.svg
+          url: https://www.sonoma.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,17 @@ jupyterhub:
           - csusonoma-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://csusonoma-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - ortegao@sonoma.edu

--- a/deployments/csusonoma/secrets/staging.yaml
+++ b/deployments/csusonoma/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:Yvv5bp5Kgu1EBivz23rnyV2h5kju3fHam5xvQptHXzm3HzsfKKYBcxECfh/fAukk97AW,iv:4LCOU11zy+JG/RquZPNGUEWgvFqslDahtpj3ALMC6fo=,tag:/oWkWA5SCfoLA8eA2Iz/8A==,type:str]
-                client_secret: ENC[AES256_GCM,data:9ICNCWn3wtMSEBwaHuN4MVZlkJvDFLuAxJA0RehyHaXGzZzBGu1QjfIVkCRFb5P14/2YXnCxm8KyMaBErBU8QyVjtAX88ZyEwoYenYysGplIWlzc5sk=,iv:+wGb0qt6ZcSN5Bq+B2ZuJrrCnoNrkEc/4No0boxKB0Y=,tag:nq8vGDUNHWOq/UkMc/4lcw==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-11-08T18:38:02Z"
-          enc: CiQA471gauFeWb9lzAm1TwIhznkCbbcH+seYNgZUt3459pchR1ASSQBxTImxX8FLgPsdInFwKmQlxPgB12qD4kQ2MF7uFTiZ8onycZGOug+1m0ZODS+bhqvYnQM49EOxhnYTYZpRZ8+yXifmwKuOu+s=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-11-08T18:38:02Z"
-    mac: ENC[AES256_GCM,data:Thym2GI3nW1pkyev6UeDr6+e0RuC8V6ERQX/Fk/qqbnpWeD1FjRIa/DXV3rTWs2wECBEexEt8CWNcwbB/h7JVhVcjGKoM3eS8xUJuBkBT14/Glgl9dnQjeAk1ocjF6wf1/PFTJcG8CzGLz4CUp2Q+5z+0ZkM2iXxz9H1Vsw/rOY=,iv:WDELWeVgnEjikMoWriLZBl5aZfnsmm9325biiDFPsXc=,tag:J9Rk9g7maK1tsOUCrEfA0A==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/dvc/config/common.yaml
+++ b/deployments/dvc/config/common.yaml
@@ -4,15 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: Diablo Valley College
-          logo_url: https://www.dvcinquirer.com/wp-content/uploads/2022/03/dvc-logo-sidebar.png
-          url: https://www.dvc.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -25,40 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - dvc.edu
-              - 4cd.edu
-              - email.4cd.edu
-              - insite.4cd.edu
-              - losmedanos.edu
-              - contracosta.edu
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - dvc.edu
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          - jedwin321@berkeley.edu
-          - sknapp@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - namato@dvc.edu
-          - llo@dvc.edu
-          - jazlin.dvc@gmail.com
-          
     # loadRoles:
       # cal-icor staff
       # cal-icor-staff:

--- a/deployments/dvc/config/prod.yaml
+++ b/deployments/dvc/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: dvc/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: Diablo Valley College
+          logo_url: https://www.dvcinquirer.com/wp-content/uploads/2022/03/dvc-logo-sidebar.png
+          url: https://www.dvc.edu/
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
@@ -21,8 +30,39 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          http://login.microsoftonline.com/common/oauth2/v2.0/authorize:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - dvc.edu
+              - 4cd.edu
+              - email.4cd.edu
+              - insite.4cd.edu
+              - losmedanos.edu
+              - contracosta.edu
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - dvc.edu
         oauth_callback_url: https://dvc.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          - jedwin321@berkeley.edu
+          - sknapp@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - namato@dvc.edu
+          - llo@dvc.edu
+          - jazlin.dvc@gmail.com
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/dvc/config/staging.yaml
+++ b/deployments/dvc/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: Diablo Valley College
+          logo_url: https://www.dvcinquirer.com/wp-content/uploads/2022/03/dvc-logo-sidebar.png
+          url: https://www.dvc.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,19 @@ jupyterhub:
           - dvc-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://dvc-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - namato@dvc.edu
+          - llo@dvc.edu
+          - jazlin.dvc@gmail.com

--- a/deployments/dvc/secrets/staging.yaml
+++ b/deployments/dvc/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:FJqyEUYvhaWS8D7UnRBx1MHfTuo4SgsDVKeDrjP0Se7Jw38bHhUvPJ9R6wJiaCGtITUa,iv:G+TJ78q00nKsPM7otNsOPU+d8fWp5oEqSoiIX9tTPqk=,tag:8UwBwDO1t54QL3S40zurgQ==,type:str]
-                client_secret: ENC[AES256_GCM,data:Vp7u/rHy6W/ODHYoy0oqJz89w3e8kPV9T0ftJ07bTP4HWdU+EEL0EtS9ex6YkMXujEwDJAgX95OEitvEjP5TJ0GhMLiJnbqYRh5yNcJeKl/w9CtEj3c=,iv:XJkQDDG6LMr+fb13H+2uWK1GBALtaOiVngL7hII3ABA=,tag:tPe6E9KUmDlMlTvZsFXiWg==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-05-12T23:52:51Z"
-          enc: CiQA471ganv53XsSUYoKIs5t4H1WgsJr6IxuSQTPRre9I3/mSzASSQA0woZQ3bWgFJVlqa8DsgcaraSP/Y1pNHdQMBb7uYxoPVjA5Rsie5RmqPW8nsajX03taMLaVF6nt4Wm0CgQCWmDHNUQIWrKA8w=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-05-12T23:52:52Z"
-    mac: ENC[AES256_GCM,data:MOesdEvCiqYBlQ7Q/z/ts27OD5zbF/wnJy/vpwR/he8HaE2v/DXMjn1vwhYspvjnqo7MSZ877uv6DB05yAQUmWXkKourWkiEWN5Pbz+OV0Z3/N5YiVv9dN/DTy17h6DWe6QIEaEAdInDkS3sPcrMRexivATxby3UH5P191Jp+1w=,iv:aJknk0oo3KEv79S9PtAd0nUY4Ewnxjb5aRPWk7EDy1M=,tag:PAAylxswjghMHgyUOtcB3Q==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/folsomlake/config/common.yaml
+++ b/deployments/folsomlake/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: Folsom Lake College
-          logo_url: https://flc.losrios.edu/flc/shared/img/admin/logos-icons/flc-desktop-logo.svg
-          url: https://www.flc.losrios.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,30 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          http://google.com/accounts/o8/id:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allowed_domains:
-              - apps.losrios.edu
-              - flc.losrios.edu
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - mukarra@flc.losrios.edu
-          - w1475529@apps.losrios.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/folsomlake/config/prod.yaml
+++ b/deployments/folsomlake/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: folsomlake/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: Folsom Lake College
+          logo_url: https://flc.losrios.edu/flc/shared/img/admin/logos-icons/flc-desktop-logo.svg
+          url: https://www.flc.losrios.edu/
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image
@@ -21,8 +30,30 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          http://google.com/accounts/o8/id:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allowed_domains:
+              - apps.losrios.edu
+              - flc.losrios.edu
         oauth_callback_url: https://folsomlake.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - mukarra@flc.losrios.edu
+          - w1475529@apps.losrios.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/folsomlake/config/staging.yaml
+++ b/deployments/folsomlake/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: Folsom Lake College
+          logo_url: https://flc.losrios.edu/flc/shared/img/admin/logos-icons/flc-desktop-logo.svg
+          url: https://www.flc.losrios.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - folsomlake-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://folsomlake-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - mukarra@flc.losrios.edu
+          - w1475529@apps.losrios.edu

--- a/deployments/folsomlake/secrets/staging.yaml
+++ b/deployments/folsomlake/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:ZPV4i4uGmJ+8UetYJuMqeTHqAVpSOvKUbvAnQFBWhlvCldV6o/GI4YEp6r52aXv3mwqZ,iv:bjG+pBlenh5m0Ema4TRH6HqLntFqS4qdIMw5OrR+fO0=,tag:xfWIUZUEeCd1IQYE6fMe/w==,type:str]
-                client_secret: ENC[AES256_GCM,data:8+EiY8mOCebJbbiqY2G7fmCvoGXSwxlHyr7n00fME7NMnfTni6Gw+O0iEUXzXgNGxXJk/hgvIVAcYORinmOLi5nsVygoGVLvOGMWaTITGco6QhDp+7c=,iv:cOfFQ9E+0UJufopj7fo0en767eZF+bHBwaL/VeT8OuU=,tag:JscuoKHuSF/odVDrf4ZZZw==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-11T00:01:14Z"
-          enc: CiQA471gamNf8ojDOqeUvyYOqrQQnrcJtwU3c//Oen4FUO+URjMSSQA0woZQM7xGIejYDrX+UcJoGLIconSRAqlXncn9l1WnH2Yvumcfs1x7Q24PQwc3dHLjtfTLRBUkFdDBZ2EGdaGrbZmWNUvTXcI=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-11T00:01:15Z"
-    mac: ENC[AES256_GCM,data:C5zyN1l1IpsOWHy72nk9kDrSVYWFDlv4t8mKzIhNJX/isphR8ez7hp8SSx4BldBoitqRLx2t359fqEt2GyQpgHc3uw2nwL3P1tfymImCzI+IIwRmYKVNJnEetcFrylxjc2W7JEuEUckiWkLEWz/h+0XEP1vTThO47LbSGd/uWdQ=,iv:SWFqn/TGPGsVJkj/ao2+1ku0TGqGceB4FrlB5uKaNBI=,tag:P0A1ztYxz8qbaIw3tYRQaA==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/fresno/config/common.yaml
+++ b/deployments/fresno/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: Fresno City College
-          logo_url: https://www.fresnocitycollege.edu/_files/images/headerlogo.png
-          url: https://www.fresnocitycollege.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,29 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          https://idp.scccd.edu/idp/shibboleth:
-            default: true
-            username_derivation:
-              username_claim: "email"
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - joellen.green@fresnocitycollege.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/fresno/config/prod.yaml
+++ b/deployments/fresno/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: fresno/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: Fresno City College
+          logo_url: https://www.fresnocitycollege.edu/_files/images/headerlogo.png
+          url: https://www.fresnocitycollege.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,29 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          https://idp.scccd.edu/idp/shibboleth:
+            default: true
+            username_derivation:
+              username_claim: "email"
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://fresno.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - joellen.green@fresnocitycollege.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/fresno/config/staging.yaml
+++ b/deployments/fresno/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: Fresno City College
+          logo_url: https://www.fresnocitycollege.edu/_files/images/headerlogo.png
+          url: https://www.fresnocitycollege.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,17 @@ jupyterhub:
           - fresno-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://fresno-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - joellen.green@fresnocitycollege.edu

--- a/deployments/fresno/secrets/staging.yaml
+++ b/deployments/fresno/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:zeNjre+nX/6Fam6yKGBF7y6UVIwK1IgVQHqB/Se6VM4mskO++n6Ok3TLQMXnBFE4gbn9,iv:fwkNIqpHFYojdJiDsHSoG0N7meyyJn07P+0oM0r1zLc=,tag:O2E2k++aYdQyD3gcfUA+fw==,type:str]
-                client_secret: ENC[AES256_GCM,data:lAXwEOMDM2jmCTHX6H03MqqtkVIlYAJ4Ph1Rtx9J8rqmKFqka8cR5SQOp8sNuUqTNAcoHLVaokUeBWmahIUZNsEe3mpdp9iIT6wAwNutTiphc9OAjVE=,iv:5n0+tEYLvvJZ7UoQme7WwSIjl9TZLa1kr8+z+fDVcBg=,tag:7IxUeDlHz3nJ7HgtzVfUZw==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-16T21:14:01Z"
-          enc: CiQA471gatG9LDjIy94PaF+2LONYbX/o8/OuKW2fcav/bsk3djcSSQA0woZQNmcRYHSoKQCAxVAr+EBc1OU3nWbiN5M0igWRqD9PPamRPBlFis68H8XIFGB3M+SpvlEbHIkcFZ/S89XUuUVpO5LpP6Y=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-16T21:14:02Z"
-    mac: ENC[AES256_GCM,data:FtJ+/5d0+KU+hu2rdsekVzPxMsEkUW9JB8J04mnCiTg99wCxHfkQryp/wAsvKg2jd2BdgoDGWhwKMz8be5aT0xAOrEQUwLJ6YrLtepIafGDiWfy2xdg6Fhczco1nbDMFEBOCM3cAN/cKwuelUbu5JHAHXd/+yUjENHP4MkDx1v4=,iv:eHNtPCKup/xhZf9FCTescNMs6xw+3qgXxVYw2K4BhRM=,tag:Yt0are207h7R7Sc0iQcnng==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/ucsc/config/common.yaml
+++ b/deployments/ucsc/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: University of California, Santa Cruz
-          logo_url: https://communications.ucsc.edu/wp-content/uploads/2021/04/2021-Logo-Do-2.jpg
-          url: https://www.ucsc.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,31 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          urn:mace:incommon:ucsc.edu:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - abrsvn@ucsc.edu
-          - jusimons@ucsc.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/ucsc/config/prod.yaml
+++ b/deployments/ucsc/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: ucsc/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: University of California, Santa Cruz
+          logo_url: https://communications.ucsc.edu/wp-content/uploads/2021/04/2021-Logo-Do-2.jpg
+          url: https://www.ucsc.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,31 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          urn:mace:incommon:ucsc.edu:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://ucsc.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - abrsvn@ucsc.edu
+          - jusimons@ucsc.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/ucsc/config/staging.yaml
+++ b/deployments/ucsc/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: University of California, Santa Cruz
+          logo_url: https://communications.ucsc.edu/wp-content/uploads/2021/04/2021-Logo-Do-2.jpg
+          url: https://www.ucsc.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - ucsc-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://ucsc-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - abrsvn@ucsc.edu
+          - jusimons@ucsc.edu

--- a/deployments/ucsc/secrets/staging.yaml
+++ b/deployments/ucsc/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:GiTraW4zD6rlO/qFH1Rz4CqpBYwZ/+4c7vt0RPF/M3jhPQd9APEa7xzKoGmiIDj2niJh,iv:0jL9tMGpeYvWEiTp4EzLLGCBQXmuGn7vMPfZi1pQ5PM=,tag:2ZUg45eBUb1DAQYFK5gWUw==,type:str]
-                client_secret: ENC[AES256_GCM,data:wdTF0c3m+J4+lD+VN0ozx4edAnwUOTI/LTxUjhA2B7+fiu2SNKN+M2i0tjFd0yDeO6dyFCK+F989r+1cbZqMIfXDCinLaEoi8OFouCJ8IqiIxceANQA=,iv:ZRsEUaoNJUbfN2cUD3nepryAdDHbUhPeroXTXb91Xfo=,tag:UMggzw0SflUaOpneyb5sAA==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-24T00:09:24Z"
-          enc: CiQA471gam3uxfwBoZaKcXsJQk8HZDIZaRs8zVCA00NKTsjTedESSQA0woZQUuc4B4CNU1QqsHickAiOG9F/1oUkXHLOWRF+xWR8IQ+4ROBvGMIZRh8Kx3Ijz1JIC2aAxuYhaXGs2su6jlWPWVsOfOk=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-24T00:09:25Z"
-    mac: ENC[AES256_GCM,data:ecKx3TnGhnGXvqvWCohDdyiGrSOCSXKhGPGb3ltt4y6B1PcMEch/LlP61Iv9c+NcN1V4KquWyZ9IrJfh+zUyoWHU1bWih/vXzjf0aypBTFo54Hd9n2jOIS2EdU754oCEBnafOCEksgMgPakapDgvtCdi5BgFYbAxkBOGgWW77DA=,iv:WsCHeiGyPpWWf/StmyBz1sgVb/xGgvmENDT3QSsLuy8=,tag:0YaZDvanekLMCs6nMaOyIA==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3

--- a/deployments/usc/config/common.yaml
+++ b/deployments/usc/config/common.yaml
@@ -4,16 +4,6 @@ nfsPVC:
     serverIP: 34.118.238.48
 
 jupyterhub:
-  custom:
-    homepage:
-      # gitRepoBranch: "username-and-password-homepage"
-      gitRepoBranch: "main"
-      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
-      templateVars:
-        org:
-          name: University of Southern California
-          logo_url: https://identity.usc.edu/wp-content/uploads/2023/05/IdentitySite_MarksLogotypes_Card_606x330.png
-          url: https://usc.edu/
   scheduling:
     userScheduler:
       nodeSelector:
@@ -26,31 +16,6 @@ jupyterhub:
   hub:
     nodeSelector:
       hub.jupyter.org/pool-name: core-pool-2026-06-30
-    config:
-      JupyterHub:
-        authenticator_class: cilogon
-      CILogonOAuthenticator:
-        # temporarily disable token refresh to fix admin access to singleuser servers
-        refresh_pre_spawn: false
-        allowed_idps:
-          urn:mace:incommon:usc.edu:
-            default: true
-            username_derivation:
-              username_claim: "email"
-            allow_all: true
-          http://google.com/accounts/o8/id:
-            username_derivation:
-              username_claim: "email"
-      Authenticator:
-        manage_groups: false
-        admin_users:
-          # infrastructure
-          - jedwin321@berkeley.edu
-          - ericvd@berkeley.edu
-          - sean.smorris@berkeley.edu
-          - sknapp@berkeley.edu
-          - kristof@usc.edu
-          - kwalther@usc.edu
   singleuser:
     image:
       name: us-central1-docker.pkg.dev/cal-icor-hubs/user-images/base-user-image

--- a/deployments/usc/config/prod.yaml
+++ b/deployments/usc/config/prod.yaml
@@ -3,6 +3,15 @@ nfsPVC:
     shareName: usc/prod
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "main"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: University of Southern California
+          logo_url: https://identity.usc.edu/wp-content/uploads/2023/05/IdentitySite_MarksLogotypes_Card_606x330.png
+          url: https://usc.edu/
   ingress:
     enabled: true
     hosts:
@@ -17,8 +26,31 @@ jupyterhub:
         # This also holds logs
         storage: 4Gi
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       CILogonOAuthenticator:
+        # temporarily disable token refresh to fix admin access to singleuser servers
+        refresh_pre_spawn: false
+        allowed_idps:
+          urn:mace:incommon:usc.edu:
+            default: true
+            username_derivation:
+              username_claim: "email"
+            allow_all: true
+          http://google.com/accounts/o8/id:
+            username_derivation:
+              username_claim: "email"
         oauth_callback_url: https://usc.jupyter.cal-icor.org/hub/oauth_callback
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sknapp@berkeley.edu
+          - kristof@usc.edu
+          - kwalther@usc.edu
     loadRoles:
       cloudbank-pilot-hub-users:
         services:

--- a/deployments/usc/config/staging.yaml
+++ b/deployments/usc/config/staging.yaml
@@ -5,6 +5,15 @@ nfsPVC:
     enabled: false
 
 jupyterhub:
+  custom:
+    homepage:
+      gitRepoBranch: "username-and-password-homepage"
+      gitRepoUrl: "https://github.com/cal-icor/default-hub-homepage"
+      templateVars:
+        org:
+          name: University of Southern California
+          logo_url: https://identity.usc.edu/wp-content/uploads/2023/05/IdentitySite_MarksLogotypes_Card_606x330.png
+          url: https://usc.edu/
   scheduling:
     userScheduler:
       replicas: 1
@@ -21,5 +30,18 @@ jupyterhub:
           - usc-staging.jupyter.cal-icor.org
   hub:
     config:
-      CILogonOAuthenticator:
-        oauth_callback_url: https://usc-staging.jupyter.cal-icor.org/hub/oauth_callback
+      JupyterHub:
+        admin_access: true
+        authenticator_class: dummy
+      Authenticator:
+        manage_groups: false
+        admin_users:
+          # infrastructure
+          - jedwin321@berkeley.edu
+          - sknapp
+          - eric_vandusen@berkeley.edu
+          - ericvd@berkeley.edu
+          - sean.smorris@berkeley.edu
+          - sean.smorris
+          - kristof@usc.edu
+          - kwalther@usc.edu

--- a/deployments/usc/secrets/staging.yaml
+++ b/deployments/usc/secrets/staging.yaml
@@ -1,20 +1,28 @@
 jupyterhub:
+    #ENC[AES256_GCM,data:Ao4gNPWzpYUii1k2nOt+,iv:ydqIPCDD4mU1QT4T6MB3GpZV+O88b6jgPABVc8apX9s=,tag:D5tH4lFW7yeGJmbDRw1n1A==,type:comment]
+    #ENC[AES256_GCM,data:KScV7er0NGkH4yC7eQlc,iv:/bu9UPT8Le+WNsBS+Ql6svL6msqAQAJqTxBNhcuEERw=,tag:r09337eQv4+En8TeKeEuvw==,type:comment]
+    #ENC[AES256_GCM,data:CPRRYGdR+uqbSYXAgcufLus7qrEUrZZ/kksAJU6+LWUgoIkcwhEJoRhM2/eC6JX+Sm56khh0mwPr1A==,iv:eNarpb84yA32remYlySKXmsTExuX6G/T41CNejtPElM=,tag:3c8YXsXFCSCLEklSHwTHwA==,type:comment]
     hub:
         config:
-            CILogonOAuthenticator:
-                client_id: ENC[AES256_GCM,data:A4um9i+STem2tYLrq+0TTWXsbHjpgQKIc3S7ZjX6/nlS/L6fYB1yn79tbMBFAoQgYLc=,iv:9qjMj0cgxCGHkPU4pQ1X1MonpPMb0FYoEvIExLWqAgM=,tag:u/P3Vl0GjJUtd3pb6cPwuA==,type:str]
-                client_secret: ENC[AES256_GCM,data:9QjvMTyznZiA09Kgk49b7wsv/HSQY+omPaCdWVZP6OZCNJbqOIUSZrxKj5YlpmMl4049hWdwhRB2LZj6ykkX56HTravxuX+Lh2+BLvunWb8WqQMGOV4=,iv:4HPevaH2zGU0kgz7GesnlWElZeB48UfgopVhgRjKgIU=,tag:CEBMmLRb1uMrggaVXhR4/A==,type:str]
+            DummyAuthenticator:
+                password: ENC[AES256_GCM,data:NRyY5HyglflmuIUqqmITrUJ4L+8CufqljQ==,iv:KsC1NvYDg+ZM7UuhALey74mzZocnGtDw+Us2jpjZDAY=,tag:0RKxBvrGg9xc2hMK2e2XSQ==,type:str]
+                #ENC[AES256_GCM,data:QhaIfQ1Q/hwZL+639Ozm,iv:Zc7bCwoZ1Srv8cBe8TNJ6r3Gwvc5Qx45IrRKPE7YYVU=,tag:jYpWffGsfjYH4HBQIiPrIQ==,type:comment]
+                #ENC[AES256_GCM,data:IUsLtx9TZkfQtZIWctb+MkEelgmcDwzhKdqlolGlz7ttUvYC8soyhbxC1JCsEtQotzLpzNMCJ2xodfucJr5ESJiosUk6u/pd,iv:2K1XMI7gVgl+tc/jLRYMEBINr+72i9romKPlN260XMc=,tag:PeRPKHhh0FkM4KXRYpg/BQ==,type:comment]
+                #ENC[AES256_GCM,data:eWhU9PiXDKtirfgI2hJNgsajUuEeJd1erSN7fG/tIw==,iv:i8X8faaLJgXU9TgrEXMpYyLJEds4TUAhd7W7mBlO6F0=,tag:zDNjiJFJw75f5J8DQkubmQ==,type:comment]
+                #ENC[AES256_GCM,data:hWifjPiyjxT9/bgtlmqGbw8kdqTUGIoFaKDxCFq6F+YcdHydxDz6ercVVv7l63vxFI6HlJGI4Q==,iv:m6wuUAnKjUTVWXTi4xKoQ3XHD6d9WVrh+ndQ1/iGXX4=,tag:F16eeiWnUfXOUQkWkkobfQ==,type:comment]
+                #ENC[AES256_GCM,data:G4jRRtW/TbOem0U=,iv:D1W4vE06cf+Zi4rhjLXOx4ry2chUV+cU7C3g7R86T9I=,tag:Fa330L32eFFyluxwK1L1cA==,type:comment]
+                #ENC[AES256_GCM,data:JFHafweOukdEapfeHLc78Wb+zaYiJuwPN0qn,iv:Zm2MeL+Pf+iGEcydE8uBGnOIqbPT42yfbftt6TtY2xA=,tag:zF1SeEkaIwDUiorYyINaIQ==,type:comment]
 sops:
     kms: []
     gcp_kms:
         - resource_id: projects/cal-icor-hubs/locations/global/keyRings/jupyterhubs/cryptoKeys/sops
-          created_at: "2025-06-26T23:41:44Z"
-          enc: CiQA471galFRbA70RkYGmkqNsE5VJ2nYkIXM3QhlgKwZtdkEnD0SSQA0woZQeKZiTx8NF+kBZnDAXfF7FhTGKXu43uwWOkX+S96060Jl7UGZyMTrYFEuXttYykNv+X+g9OdMSDSvozqbBOwm7lN/Pf0=
+          created_at: "2025-04-25T21:34:00Z"
+          enc: CiQA471galwWWwZ/ZXwW7+566jHEaKNaSjnnYRYUb/mFNSQmXIUSSQAjg8vZliK91DIi89Y4tCNrKUQrQgO43UEoc7Cw0ho5fNC7tBDck0Q8kyvittTq7ALoSW5Ff6WairkfN/HtglXMOp1JjEjK4mo=
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-06-26T23:41:44Z"
-    mac: ENC[AES256_GCM,data:gdTYdukdqPXRX6CkjDEvvwU5exe6xpx/7qBXvUd+pNuY5JFhxGFUwBM5BE4l+AoNoI8SWRvVaLZgZViHx5w3H2YLf4ArMq/wk8UWwNt2cUXvbVq0Dc3mMWaqfYZLq73EDWqKnp/TM2RbRx8iDEX/VnpMT0xeNAf2H5wYeIuUgyA=,iv:GAAkr9spTXdyh3CyrGovNvZg4iEKbEJYt+pMOmEJUUs=,tag:+jeqkg52BAUoCTezT5yiQg==,type:str]
+    lastmodified: "2026-07-01T20:50:32Z"
+    mac: ENC[AES256_GCM,data:/oBKIKsLkhFjrFJXR3wXZsQ+ZLnZmibsJfNJu7iu4wWAsCMzfSZJn1HKKf3FOif+E7vOoZpXkUdZjLpnMtdr8K6e+YKDDN7zQOkFqkC1DJAEbp5UUtSzi2yUeRxCzXsUmn+iZrXhcGT0yVGnlWKspucx2Pi/uQgCj3sca+dykw4=,iv:lp34ziKFMEslrUwbdi+KS/3fgfpLFfljOKhSB2ARFpg=,tag:4FlVmYdPZa8xva/MpR3CpQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.7.3


### PR DESCRIPTION
ref: https://github.com/cal-icor/cal-icor-hubs/issues/916

for each hub:

1. move cilogon-based auth to `prod.yaml`, tidy up the auth stanza
2. update `staging.yaml` with `DummyAuthenticator` auth
3. use `username-and-password` branch for hub homepage in `staging.yaml`
4. `cp deployments/jupyter/secrets/staging.yaml` in to `deployments/<hub>/secrets/`, overwriting the cilogon bits
5. ...
6. profit?

and then update `create_deployment.py` and the `cookiecutter` template to do this automagically for future deployments.

first commit is `chicostate`, which i've deployed manually to both `staging` and `prod` and confirmed that both auth schemes are present and working as intended.  commented out sections will be removed before merging.