### PR TITLE
bump `jupyterhub-home-nfs` chart version

### DIFF
--- a/jupyterhub-home-nfs/Chart.yaml
+++ b/jupyterhub-home-nfs/Chart.yaml
@@ -5,5 +5,5 @@ name: jupyterhub-home-nfs
 version: 0.0.1+1750.5619aab
 dependencies:
   - name: jupyterhub-home-nfs
-    version: 1.2.1-0.dev.git.1.hd7e9643
+    version: 1.2.1-0.dev.git.1.h363b75f
     repository: oci://ghcr.io/2i2c-org/jupyterhub-home-nfs


### PR DESCRIPTION
this pulls in my `nfs-server` package addition PR (https://github.com/2i2c-org/jupyterhub-home-nfs/pull/87), as well as testing out the nfs deployment gate in the new CI/CD gated workflow schema (https://github.com/cal-icor/cal-icor-hubs/pull/958)